### PR TITLE
expose some internal request-/response-building functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for egg-mode
 
+## Pending
+
+### Added
+- New module `raw`, for binding APIs that egg-mode doesn't wrap
+  - Various `request_*` and `response_*` functions to assemble and execute signed API requests
+  - New type `ParamList` to represent a list of parameters to an API call
+  - New `raw` example showing how to pull the raw JSON from fetching a tweet
+
 ## [0.14.0]
 
 This release has a lot of important changes!

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+mod common;
+
+// By using the `raw` module, you can add in extra parameters that egg-mode doesn't add, or parse
+// the response exactly the way you want.
+//
+// This example shows how to use the `raw` API to load a tweet, like with `tweet::show`.
+
+use egg_mode::Response;
+use egg_mode::raw;
+
+#[tokio::main]
+async fn main() {
+    let config = common::Config::load().await;
+
+    let url = "https://api.twitter.com/1.1/statuses/show.json";
+    let tweet_id: u64 = 1261253754969640960;
+
+    let params = raw::ParamList::new()
+        .extended_tweets()
+        .add_param("id", tweet_id.to_string());
+
+    let req = raw::request_get(url, &config.token, Some(&params));
+    let output: Response<serde_json::Value> = raw::response_json(req).await.unwrap();
+    let json = output.response;
+
+    // now that we have the response as plain JSON, we can directly access the fields we want
+    let user_name = json["user"]["name"].as_str().unwrap();
+    let screen_name = json["user"]["screen_name"].as_str().unwrap();
+
+    // in tweet JSON, the text of the tweet can be in three places. In plain tweets without setting
+    // `extended_tweets` above, the "text" field has the text, but it may be truncated if the tweet
+    // is over 140 characters. In this case, the full text will be available in the
+    // "extended_tweet" field, which contains the complete text and all the extended entities. If
+    // you do set `extended_tweets`, then the tweet that gets returned is the same as what would
+    // have been in "extended_tweet", and the "full_text" field needs to be checked.
+    //
+    // (This is checked as part of the Deserialize impl for Tweets.)
+    let text = if let Some(t) = json["extended_tweet"]["full_text"].as_str() {
+        t
+    } else if let Some(t) = json["full_text"].as_str() {
+        t
+    } else if let Some(t) = json["text"].as_str() {
+        t
+    } else {
+        panic!("couldn't load text from tweet?");
+    };
+
+    println!("{} (@{}) tweeted:", user_name, screen_name);
+    println!("---");
+    println!("{}", text);
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -408,7 +408,11 @@ fn bearer_request(con_token: &KeyPair) -> String {
 }
 
 /// Assemble a signed GET request to the given URL with the given parameters.
-pub(crate) fn get(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
+///
+/// The given parameters, if present, will be appended to the given `uri` as a percent-encoded
+/// query string. If the given `token` is not a Bearer token, the parameters will also be used to
+/// create the OAuth signature.
+pub fn get(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
     let full_url = if let Some(p) = params {
         let query = p
             .iter()
@@ -445,7 +449,11 @@ pub(crate) fn get(uri: &str, token: &Token, params: Option<&ParamList>) -> Reque
 }
 
 /// Assemble a signed POST request to the given URL with the given parameters.
-pub(crate) fn post(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
+///
+/// The given parameters, if present, will be percent-encoded and included in the POST body with a
+/// content-type of `application/x-www-form-urlencoded`. If the given `token` is not a Bearer
+/// token, the parameters will also be used to create the OAuth signature.
+pub fn post(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
     let content = "application/x-www-form-urlencoded";
     let body = if let Some(p) = params {
         Body::from(
@@ -484,6 +492,11 @@ pub(crate) fn post(uri: &str, token: &Token, params: Option<&ParamList>) -> Requ
 }
 
 /// Assemble a signed POST request to the given URL with the given JSON body.
+///
+/// This method of building requests allows you to use endpoints that require a request body of
+/// plain text or JSON, like `POST media/metadata/create`. Note that this function does not encode
+/// its parameters into the OAuth signature, so take care if the endpoint you're using lists
+/// parameters as part of its specification.
 pub fn post_json<B: serde::Serialize>(uri: &str, token: &Token, body: B) -> Request<Body> {
     let content = "application/json; charset=UTF-8";
     let body = Body::from(serde_json::to_string(&body).unwrap()); // TODO rewrite

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -407,6 +407,7 @@ fn bearer_request(con_token: &KeyPair) -> String {
     format!("Basic {}", base64::encode(&text))
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Assemble a signed GET request to the given URL with the given parameters.
 ///
 /// The given parameters, if present, will be appended to the given `uri` as a percent-encoded
@@ -448,11 +449,12 @@ pub fn get(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body
     request.body(Body::empty()).unwrap()
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Assemble a signed POST request to the given URL with the given parameters.
 ///
-/// The given parameters, if present, will be percent-encoded and included in the POST body with a
-/// content-type of `application/x-www-form-urlencoded`. If the given `token` is not a Bearer
-/// token, the parameters will also be used to create the OAuth signature.
+/// The given parameters, if present, will be percent-encoded and included in the POST body
+/// formatted with a content-type of `application/x-www-form-urlencoded`. If the given `token` is
+/// not a Bearer token, the parameters will also be used to create the OAuth signature.
 pub fn post(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
     let content = "application/x-www-form-urlencoded";
     let body = if let Some(p) = params {
@@ -491,6 +493,7 @@ pub fn post(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Bod
     request.body(body).unwrap()
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Assemble a signed POST request to the given URL with the given JSON body.
 ///
 /// This method of building requests allows you to use endpoints that require a request body of

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -99,24 +99,29 @@ mod response;
 pub use crate::common::response::*;
 use crate::{error, list, user};
 
+/// A set of headers returned with a response.
 pub type Headers = HeaderMap<HeaderValue>;
-pub(crate) type CowStr = Cow<'static, str>;
+pub type CowStr = Cow<'static, str>;
 
-///Convenience type used to hold parameters to an API call.
+/// Represents a list of parameters to a Twitter API call.
 #[derive(Debug, Clone, Default, derive_more::Deref, derive_more::DerefMut, derive_more::From)]
-pub(crate) struct ParamList(HashMap<Cow<'static, str>, Cow<'static, str>>);
+pub struct ParamList(HashMap<Cow<'static, str>, Cow<'static, str>>);
 
 impl ParamList {
-    pub(crate) fn new() -> Self {
+    /// Creates a new, empty `ParamList`.
+    pub fn new() -> Self {
         Self(HashMap::new())
     }
 
-    pub(crate) fn extended_tweets(self) -> Self {
+    /// Adds the `tweet_mode=extended` parameter to this `ParamList`. Not including this parameter
+    /// will cause tweets to be loaded with legacy parameters, and a potentially-truncated `text`
+    /// if the tweet is longer than 140 characters.
+    pub fn extended_tweets(self) -> Self {
         self.add_param("tweet_mode", "extended")
     }
 
-    ///Convenience function to add a key/value parameter to a `ParamList`.
-    pub(crate) fn add_param(
+    /// Adds the given key/value parameter to this `ParamList`.
+    pub fn add_param(
         mut self,
         key: impl Into<Cow<'static, str>>,
         value: impl Into<Cow<'static, str>>,
@@ -125,8 +130,8 @@ impl ParamList {
         self
     }
 
-    ///Convenience function to add a key/value parameter to a `ParamList`.
-    pub(crate) fn add_opt_param(
+    /// Adds the given key/value parameter to this `ParamList` only if the given value is `Some`.
+    pub fn add_opt_param(
         self,
         key: impl Into<Cow<'static, str>>,
         value: Option<impl Into<Cow<'static, str>>>,
@@ -137,8 +142,9 @@ impl ParamList {
         }
     }
 
-    ///Convenience function to add a key/value parameter to a `ParamList` without moving.
-    pub(crate) fn add_param_ref(
+    /// Adds the given key/value to this `ParamList` by mutating it in place, rather than consuming
+    /// it as in `add_param`.
+    pub fn add_param_ref(
         &mut self,
         key: impl Into<Cow<'static, str>>,
         value: impl Into<Cow<'static, str>>,
@@ -146,14 +152,18 @@ impl ParamList {
         self.0.insert(key.into(), value.into());
     }
 
-    pub(crate) fn add_name_param(self, id: user::UserID) -> Self {
+    /// Adds the given `UserID` as a parameter to this `ParamList` by adding either a `user_id` or
+    /// `screen_name` parameter as appropriate.
+    pub fn add_name_param(self, id: user::UserID) -> Self {
         match id {
             user::UserID::ID(id) => self.add_param("user_id", id.to_string()),
             user::UserID::ScreenName(name) => self.add_param("screen_name", name),
         }
     }
 
-    pub(crate) fn add_list_param(mut self, list: list::ListID) -> Self {
+    /// Adds the given `ListID` as a parameter to this `ParamList` by adding either an owner/slug
+    /// pair or a `list_id`, as appropriate.
+    pub fn add_list_param(mut self, list: list::ListID) -> Self {
         match list {
             list::ListID::Slug(owner, name) => {
                 match owner {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -27,7 +27,7 @@
 //! `add_param` is a basic function that turns its arguments into `Cow<'static, str>`, then inserts them
 //! as a parameter into the given `ParamList`.
 //!
-//! `add_name_param` provides some special handling for the `UserID` enum, since Twitter always
+//! `add_user_param` provides some special handling for the `UserID` enum, since Twitter always
 //! handles user parameters the same way: either as a `"user_id"` parameter with the ID, or as a
 //! `"screen_name"` parameter with the screen name. Since that's also how the `UserID` enum is laid
 //! out, this just puts the right parameter into the given `ParamList`.
@@ -124,7 +124,7 @@ pub type CowStr = Cow<'static, str>;
 /// // ParamList like this...
 /// let params = ParamList::new()
 ///     .extended_tweets()
-///     .add_name_param("rustlang".into());
+///     .add_user_param("rustlang".into());
 /// ```
 #[derive(Debug, Clone, Default, derive_more::Deref, derive_more::DerefMut, derive_more::From)]
 pub struct ParamList(HashMap<Cow<'static, str>, Cow<'static, str>>);
@@ -182,7 +182,7 @@ impl ParamList {
 
     /// Adds the given `UserID` as a parameter to this `ParamList` by adding either a `user_id` or
     /// `screen_name` parameter as appropriate.
-    pub fn add_name_param(self, id: user::UserID) -> Self {
+    pub fn add_user_param(self, id: user::UserID) -> Self {
         match id {
             user::UserID::ID(id) => self.add_param("user_id", id.to_string()),
             user::UserID::ScreenName(name) => self.add_param("screen_name", name),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -99,6 +99,7 @@ mod response;
 pub use crate::common::response::*;
 use crate::{error, list, user};
 
+// n.b. this type alias is re-exported in the `raw` module - these docs are public!
 /// A set of headers returned with a response.
 pub type Headers = HeaderMap<HeaderValue>;
 pub type CowStr = Cow<'static, str>;
@@ -136,7 +137,9 @@ impl ParamList {
 
     /// Adds the `tweet_mode=extended` parameter to this `ParamList`. Not including this parameter
     /// will cause tweets to be loaded with legacy parameters, and a potentially-truncated `text`
-    /// if the tweet is longer than 140 characters.
+    /// if the tweet is longer than 140 characters. The `Deserialize` impl for `Tweet`s (or
+    /// anything that directly or indirectly includes a `Tweet`) expects the extended tweet format
+    /// enabled by this function.
     pub fn extended_tweets(self) -> Self {
         self.add_param("tweet_mode", "extended")
     }

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -44,6 +44,7 @@ fn rate_limit_reset(headers: &Headers) -> Result<Option<i32>> {
     rate_limit(headers, X_RATE_LIMIT_RESET)
 }
 
+// n.b. this type is re-exported at the crate root - these docs are public!
 ///A helper struct to wrap response data with accompanying rate limit information.
 ///
 ///This is returned by any function that calls a rate-limited method on Twitter, to allow for
@@ -83,6 +84,7 @@ impl<T> Response<T> {
     }
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Converts the given request into a raw `ResponseFuture` from hyper.
 pub fn get_response(request: Request<Body>) -> ResponseFuture {
     let connector = HttpsConnector::new();
@@ -90,6 +92,7 @@ pub fn get_response(request: Request<Body>) -> ResponseFuture {
     client.request(request)
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Loads the given request, parses the headers and response for potential errors given by Twitter,
 /// and returns the headers and raw bytes returned from the response.
 pub async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
@@ -113,6 +116,7 @@ pub async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
     Ok((parts.headers, body))
 }
 
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Loads the given request and parses the response as JSON into the given type, including
 /// rate-limit headers.
 pub async fn request_with_json_response<T: DeserializeOwned>(

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -83,13 +83,16 @@ impl<T> Response<T> {
     }
 }
 
-pub(crate) fn get_response(request: Request<Body>) -> ResponseFuture {
+/// Converts the given request into a raw `ResponseFuture` from hyper.
+pub fn get_response(request: Request<Body>) -> ResponseFuture {
     let connector = HttpsConnector::new();
     let client = hyper::Client::builder().build(connector);
     client.request(request)
 }
 
-pub(crate) async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
+/// Loads the given request, parses the headers and response for potential errors given by Twitter,
+/// and returns the headers and raw bytes returned from the response.
+pub async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
     let connector = HttpsConnector::new();
     let client = hyper::Client::builder().build(connector);
     let resp = client.request(request).await?;
@@ -110,9 +113,9 @@ pub(crate) async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<
     Ok((parts.headers, body))
 }
 
-/// Convenience method that attempts to parse the given type from the response and
-/// loads rate-limit information from the response headers.
-pub(crate) async fn request_with_json_response<T: DeserializeOwned>(
+/// Loads the given request and parses the response as JSON into the given type, including
+/// rate-limit headers.
+pub async fn request_with_json_response<T: DeserializeOwned>(
     request: Request<Body>,
 ) -> Result<Response<T>> {
     let (headers, body) = raw_request(request).await?;

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -40,7 +40,7 @@ pub async fn send<T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<DirectMessage>, error::Error> {
     let params = ParamList::new()
-        .add_name_param(to.into())
+        .add_user_param(to.into())
         .add_param("text", text);
 
     let req = auth::post(links::direct::SEND, token, Some(&params));

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -339,7 +339,7 @@ impl Timeline {
     }
 
     ///Create an instance of `Timeline` with the given link and tokens.
-    fn new(link: &'static str, params_base: Option<ParamList>, token: &auth::Token) -> Self {
+    pub(crate) fn new(link: &'static str, params_base: Option<ParamList>, token: &auth::Token) -> Self {
         Timeline {
             link: link,
             token: token.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ mod links;
 pub mod list;
 pub mod media;
 pub mod place;
+pub mod raw;
 pub mod search;
 pub mod service;
 pub mod stream;

--- a/src/list/fun.rs
+++ b/src/list/fun.rs
@@ -17,7 +17,7 @@ use crate::{auth, links, tweet};
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn memberships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(user.into());
+    let params = ParamList::new().add_user_param(user.into());
     CursorIter::new(links::lists::MEMBERSHIPS, token, Some(params), Some(20))
 }
 
@@ -38,7 +38,7 @@ pub async fn list<'id, T: Into<UserID>>(
     token: &auth::Token,
 ) -> Result<Response<Vec<List>>> {
     let params = ParamList::new()
-        .add_name_param(user.into())
+        .add_user_param(user.into())
         .add_param("reverse", owned_first.to_string());
 
     let req = auth::get(links::lists::LIST, token, Some(&params));
@@ -51,7 +51,7 @@ pub async fn list<'id, T: Into<UserID>>(
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn subscriptions<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(user.into());
+    let params = ParamList::new().add_user_param(user.into());
     CursorIter::new(links::lists::SUBSCRIPTIONS, token, Some(params), Some(20))
 }
 
@@ -60,7 +60,7 @@ pub fn subscriptions<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIte
 ///This function returns a `Stream` over the lists returned by Twitter. This method defaults to
 ///reeturning 20 lists in a single network call; the maximum is 1000.
 pub fn ownerships<T: Into<UserID>>(user: T, token: &auth::Token) -> CursorIter<ListCursor> {
-    let params = ParamList::new().add_name_param(user.into());
+    let params = ParamList::new().add_user_param(user.into());
     CursorIter::new(links::lists::OWNERSHIPS, token, Some(params), Some(20))
 }
 
@@ -101,7 +101,7 @@ pub async fn is_subscribed<'id, T: Into<UserID>>(
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
         .add_list_param(list)
-        .add_name_param(user.into());
+        .add_user_param(user.into());
 
     let req = auth::get(links::lists::IS_SUBSCRIBER, token, Some(&params));
 
@@ -132,7 +132,7 @@ pub async fn is_member<'id, T: Into<UserID>>(
 ) -> Result<Response<bool>> {
     let params = ParamList::new()
         .add_list_param(list)
-        .add_name_param(user.into());
+        .add_user_param(user.into());
 
     let req = auth::get(links::lists::IS_MEMBER, token, Some(&params));
     let out = request_with_json_response::<TwitterUser>(req).await;
@@ -180,7 +180,7 @@ pub async fn add_member<'id, T: Into<UserID>>(
 ) -> Result<Response<List>> {
     let params = ParamList::new()
         .add_list_param(list)
-        .add_name_param(user.into());
+        .add_user_param(user.into());
 
     let req = auth::post(links::lists::ADD, token, Some(&params));
 
@@ -242,7 +242,7 @@ pub async fn remove_member<'id, T: Into<UserID>>(
 ) -> Result<Response<List>> {
     let params = ParamList::new()
         .add_list_param(list)
-        .add_name_param(user.into());
+        .add_user_param(user.into());
 
     let req = auth::post(links::lists::REMOVE_MEMBER, token, Some(&params));
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -3,6 +3,36 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //! Raw access to request- and response-building primitives used internally by egg-mode.
+//!
+//! The functions and types exposed in this module allow you to access Twitter API functions that
+//! aren't currently wrapped by egg-mode, or to provide parameters to Twitter that egg-mode doesn't
+//! currently use. These functions also allow you to have more power in how you process the data
+//! returned by Twitter. In return, much more knowledge of the Twitter API is required to
+//! effectively use these functions.
+//!
+//! The functions in this module can be divided into two categories: assembling a request, and
+//! executing it to get a response. Some wrapper types in egg-mode operate directly on requests, or
+//! create their own, so constructors for those types are also exposed here.
+//!
+//! The functions that create `Request`s (or that assemble a type that creates its own `Requests`)
+//! all require a `Token`, like the rest of egg-mode, which lets them properly create the
+//! corresponding OAuth signature for the call. They also take a `ParamList` instance, which is
+//! used to store parameters to the API call. These correspond to the parameters listed on the API
+//! Reference page for the given endpoint you would like to call.
+//!
+//! Once you have a `Request`, you can hand it to the `response_*` functions in this module to
+//! process it. Which one you select depends on how much processing you want egg-mode to do with
+//! the response.
+//!
+//! * At the most hands-off end, there's `response_future`, which is a small wrapper that just
+//!   starts the request and hands off the `ResponseFuture` from `hyper` to give you the most power
+//!   over handling the response data.
+//! * In the middle, there's `response_raw_bytes`, which wraps the `ResponseFuture` to return the
+//!   headers and response body after inspecting the rate-limit headers and response code, and
+//!   after inspecting the response to see whether it returned error data from Twitter.
+//! * Finally there's `response_json`, which picks up from `response_raw_bytes` to parse the
+//!   response as JSON and deserialize it into the target type, alongside the rate-limit
+//!   information from the response headers.
 
 use hyper::{Body, Request};
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Raw access to request- and response-building primitives used internally by egg-mode.
+
+use hyper::{Body, Request};
+
+use crate::auth::Token;
+use crate::cursor;
+use crate::stream::TwitterStream;
+
+use crate::tweet::Timeline as TweetTimeline;
+use crate::direct::Timeline as DMTimeline;
+
+pub use crate::common::ParamList;
+pub use crate::common::Headers;
+
+pub use crate::auth::get as request_get;
+pub use crate::auth::post as request_post;
+pub use crate::auth::post_json as request_post_json;
+
+/// Assemble a GET request and convert it to a `Timeline` of tweets.
+pub fn request_as_tweet_timeline(
+    url: &'static str,
+    token: &Token,
+    params: Option<ParamList>
+) -> TweetTimeline {
+    TweetTimeline::new(url, params, token)
+}
+
+/// Assemble a GET request and convert it to a `Timeline` of direct messages.
+pub fn request_as_dm_timeline(
+    url: &'static str,
+    token: &Token,
+    params: Option<ParamList>
+) -> DMTimeline {
+    DMTimeline::new(url, params, token)
+}
+
+/// Assemble a GET request and convert it to a `CursorIter`.
+pub fn request_as_cursor_iter<T: cursor::Cursor + serde::de::DeserializeOwned>(
+    url: &'static str,
+    token: &Token,
+    params: Option<ParamList>,
+    page_size: Option<i32>
+) -> cursor::CursorIter<T> {
+    cursor::CursorIter::new(url, token, params, page_size)
+}
+
+pub use crate::common::get_response as response_future;
+pub use crate::common::raw_request as response_raw_bytes;
+pub use crate::common::request_with_json_response as response_json;
+
+/// Converts the given request into a `TwitterStream`.
+///
+/// This function can be used for endpoints that open a persistent stream, like `GET
+/// statuses/sample`. If you know that the messages returned by the stream you're using will look
+/// the same as `StreamMessage`, this can be a convenient way to customize a stream if you need to
+/// use other endpoints or options not available to `StreamBuilder`.
+pub fn response_as_stream(req: Request<Body>) -> TwitterStream {
+    TwitterStream::new(req)
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -14,25 +14,54 @@
 //! executing it to get a response. Some wrapper types in egg-mode operate directly on requests, or
 //! create their own, so constructors for those types are also exposed here.
 //!
-//! The functions that create `Request`s (or that assemble a type that creates its own `Requests`)
-//! all require a `Token`, like the rest of egg-mode, which lets them properly create the
-//! corresponding OAuth signature for the call. They also take a `ParamList` instance, which is
-//! used to store parameters to the API call. These correspond to the parameters listed on the API
-//! Reference page for the given endpoint you would like to call.
+//! To start using the functions in this module, you'll need a [`Token`] from the authentication
+//! flow. The parameters to an endpoint are represented by the [`ParamList`] type. They're
+//! separated out so that they can be included as part of the OAuth signature given to Twitter as
+//! part of the API call. This also means that the URL you give to the request functions should be
+//! the base URL, with no parameters.
+//!
+//! [`Token`]: ../enum.Token.html
+//! [`ParamList`]: struct.ParamList.html
+//!
+//! There are three basic request functions, based on how the endpoint expects to be called:
+//!
+//! * `request_get` assembles a GET request, with the given parameters appended to the URL as a
+//!   query string. All GET endpoints that egg-mode currently wraps use this function to encode and
+//!   sign the request.
+//! * `request_post` assembles a POST request, with the given parameters included in the POST body
+//!   formatted as `x-www-form-urlencoded` data. Most POST endpoints in the Twitter API are
+//!   formatted using this function.
+//! * `request_post_json` also assembles a POST request, but instead of taking a `ParamList`, it
+//!   takes arbitrary data and formats it in the POST body as JSON. The provided data is *not* used
+//!   as part of the OAuth signature. At time of writing (between releases 0.14 and 0.15) the only
+//!   egg-mode endpoint that uses this function is [`media::set_metadata`].
+//!
+//! [`media::set_metadata`]: ../media/fn.set_metadata.html
 //!
 //! Once you have a `Request`, you can hand it to the `response_*` functions in this module to
 //! process it. Which one you select depends on how much processing you want egg-mode to do with
-//! the response.
+//! the response:
 //!
-//! * At the most hands-off end, there's `response_future`, which is a small wrapper that just
+//! * At the most hands-off end, there's [`response_future`,] which is a small wrapper that just
 //!   starts the request and hands off the `ResponseFuture` from `hyper` to give you the most power
 //!   over handling the response data.
-//! * In the middle, there's `response_raw_bytes`, which wraps the `ResponseFuture` to return the
+//! * In the middle, there's [`response_raw_bytes`], which wraps the `ResponseFuture` to return the
 //!   headers and response body after inspecting the rate-limit headers and response code, and
 //!   after inspecting the response to see whether it returned error data from Twitter.
-//! * Finally there's `response_json`, which picks up from `response_raw_bytes` to parse the
+//! * Finally there's [`response_json`], which picks up from `response_raw_bytes` to parse the
 //!   response as JSON and deserialize it into the target type, alongside the rate-limit
 //!   information from the response headers.
+//!
+//! [`response_future`]: fn.response_future.html
+//! [`response_raw_bytes`]: fn.response_raw_bytes.html
+//! [`response_json`]: fn.response_json.html
+//!
+//! In addition, there are `request_as_*` and `response_as_*` functions available to format a
+//! request using one of the wrappers used in egg-mode. If the endpoint you're using is one that
+//! currently uses one of these wrapper types or returns and accepts data the same way as one of
+//! these endpoints, you can use these functions to get the same experience as the existing
+//! wrappers in egg-mode. See the documentation for these functions to see their assumptions and
+//! requirements.
 
 use hyper::{Body, Request};
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -214,7 +214,7 @@ pub struct TwitterStream {
 }
 
 impl TwitterStream {
-    fn new(request: Request<Body>) -> TwitterStream {
+    pub(crate) fn new(request: Request<Body>) -> TwitterStream {
         TwitterStream {
             buf: vec![],
             request: Some(request),

--- a/src/tweet/fun.rs
+++ b/src/tweet/fun.rs
@@ -172,7 +172,7 @@ pub fn user_timeline<T: Into<UserID>>(
 ) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into())
+        .add_user_param(acct.into())
         .add_param("exclude_replies", (!with_replies).to_string())
         .add_param("include_rts", with_rts.to_string());
 
@@ -193,7 +193,7 @@ pub fn retweets_of_me(token: &auth::Token) -> Timeline {
 pub fn liked_by<T: Into<UserID>>(acct: T, token: &auth::Token) -> Timeline {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     Timeline::new(links::statuses::LIKES_OF, Some(params), token)
 }
 

--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -94,7 +94,7 @@ where
 pub async fn show<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
 
     let req = auth::get(links::users::SHOW, token, Some(&params));
 
@@ -172,7 +172,7 @@ pub fn friends_of<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::UserCursor> {
-    let params = ParamList::new().add_name_param(acct.into());
+    let params = ParamList::new().add_user_param(acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_LIST, token, Some(params), Some(20))
 }
 
@@ -189,7 +189,7 @@ pub fn friends_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::IDCursor> {
-    let params = ParamList::new().add_name_param(acct.into());
+    let params = ParamList::new().add_user_param(acct.into());
     cursor::CursorIter::new(links::users::FRIENDS_IDS, token, Some(params), Some(500))
 }
 
@@ -203,7 +203,7 @@ pub fn followers_of<T: Into<UserID>>(
 ) -> cursor::CursorIter<cursor::UserCursor> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     cursor::CursorIter::new(links::users::FOLLOWERS_LIST, token, Some(params), Some(20))
 }
 
@@ -219,7 +219,7 @@ pub fn followers_ids<T: Into<UserID>>(
     acct: T,
     token: &auth::Token,
 ) -> cursor::CursorIter<cursor::IDCursor> {
-    let params = ParamList::new().add_name_param(acct.into());
+    let params = ParamList::new().add_user_param(acct.into());
     cursor::CursorIter::new(links::users::FOLLOWERS_IDS, token, Some(params), Some(500))
 }
 
@@ -302,7 +302,7 @@ pub async fn follow<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into())
+        .add_user_param(acct.into())
         .add_param("follow", notifications.to_string());
     let req = auth::post(links::users::FOLLOW, token, Some(&params));
     request_with_json_response(req).await
@@ -320,7 +320,7 @@ pub async fn unfollow<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::UNFOLLOW, token, Some(&params));
     request_with_json_response(req).await
 }
@@ -341,7 +341,7 @@ where
     T: Into<UserID>,
 {
     let params = ParamList::new()
-        .add_name_param(acct.into())
+        .add_user_param(acct.into())
         .add_opt_param("device", notifications.map(|v| v.to_string()))
         .add_opt_param("retweets", retweets.map(|v| v.to_string()));
     let req = auth::post(links::users::FRIENDSHIP_UPDATE, token, Some(&params));
@@ -354,7 +354,7 @@ where
 pub async fn block<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::BLOCK, token, Some(&params));
     request_with_json_response(req).await
 }
@@ -368,7 +368,7 @@ pub async fn report_spam<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::REPORT_SPAM, token, Some(&params));
     request_with_json_response(req).await
 }
@@ -382,7 +382,7 @@ pub async fn unblock<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::UNBLOCK, token, Some(&params));
     request_with_json_response(req).await
 }
@@ -393,7 +393,7 @@ pub async fn unblock<T: Into<UserID>>(
 pub async fn mute<T: Into<UserID>>(acct: T, token: &auth::Token) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::MUTE, token, Some(&params));
     request_with_json_response(req).await
 }
@@ -407,7 +407,7 @@ pub async fn unmute<T: Into<UserID>>(
 ) -> Result<Response<TwitterUser>> {
     let params = ParamList::new()
         .extended_tweets()
-        .add_name_param(acct.into());
+        .add_user_param(acct.into());
     let req = auth::post(links::users::UNMUTE, token, Some(&params));
     request_with_json_response(req).await
 }


### PR DESCRIPTION
This PR creates a new `raw` module and re-exports a handful of internal functions (or wraps those internal functions with public wrappers). This should allow users to bind arbitrary endpoints\* that egg-mode doesn't currently wrap, or to add parameters that egg-mode doesn't currently use. I stopped short of exposing all of the internal `auth` module (cc https://github.com/egg-mode-rs/egg-mode/issues/32), because i had misgivings about the state of all that code. (Also i don't want to give the idea that egg-mode code can be used as a generic OAuth library; i don't want to support OAuth models other than Twitter, TBH.)

I also decided to rename the exports to follow a request/response dichotomy, since the functions i chose to expose did one of two things:

1. Assemble a web request (or take all the same parameters as assembling a web request would, and handing that as starter data to a wrapper type that assembles the request itself), or
2. Take a previously-assembled request and process it into a response (or process it into a wrapper type that processes the response itself).

The use of renaming only the public exports means that i didn't have to change any internal code to expose this module, though it does create a situation where potential contributors has *seen* the names in the `raw` module, but can't use those names internally when binding new endpoints. This is a potential refactoring possibility later, i guess.

-----

(\*: Almost. There are some DELETE endpoints and one PUT endpoint that aren't possible yet, because there's no ability to create requests with those HTTP verbs. Creating a DELETE wrapper should be simple since it works the same as GET, but the one endpoint that uses PUT will be an odd duck, because it uses query-string parameters *and* a request body, which just breaks our model. :expressionless:)

closes https://github.com/egg-mode-rs/egg-mode/issues/83