### PR TITLE
expose a generic raw request builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - Various `request_*` and `response_*` functions to assemble and execute signed API requests
   - New type `ParamList` to represent a list of parameters to an API call
   - New `raw` example showing how to pull the raw JSON from fetching a tweet
+  - Sub-module `raw::auth` containing a generic `RequestBuilder` for purposes that `raw` itself
+    doesn't enable
 - `RateLimit` is now an exposed type with its own docs
 
 ### Changed

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -186,8 +186,7 @@
 
 use std::borrow::Cow;
 
-use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
-use hyper::{Body, Method, Request};
+use hyper::Method;
 use serde::{Serialize, Deserialize};
 use serde_json;
 
@@ -340,14 +339,9 @@ pub enum Token {
 /// # }
 /// ```
 pub async fn request_token<S: Into<String>>(con_token: &KeyPair, callback: S) -> Result<KeyPair> {
-    let header = OAuthParams::from_keys(con_token.clone(), None)
-        .with_callback(callback.into())
-        .sign_request(Method::POST, links::auth::REQUEST_TOKEN, None);
-
-    let request = Request::post(links::auth::REQUEST_TOKEN)
-        .header(AUTHORIZATION, header.to_string())
-        .body(Body::empty())
-        .unwrap();
+    let request = RequestBuilder::new(Method::POST, links::auth::REQUEST_TOKEN)
+        .oauth_callback(callback.into())
+        .request_keys(con_token, None);
 
     let (_, body) = raw_request(request).await?;
 
@@ -513,14 +507,9 @@ pub async fn access_token<S: Into<String>>(
     request_token: &KeyPair,
     verifier: S,
 ) -> Result<(Token, u64, String)> {
-    let header = OAuthParams::from_keys(con_token.clone(), Some(request_token.clone()))
-        .with_verifier(verifier.into())
-        .sign_request(Method::POST, links::auth::ACCESS_TOKEN, None);
-
-    let request = Request::post(links::auth::ACCESS_TOKEN)
-        .header(AUTHORIZATION, header.to_string())
-        .body(Body::empty())
-        .unwrap();
+    let request = RequestBuilder::new(Method::POST, links::auth::ACCESS_TOKEN)
+        .oauth_verifier(verifier.into())
+        .request_keys(&con_token, Some(request_token));
 
     let (_headers, urlencoded) = raw_request(request).await?;
     let urlencoded = std::str::from_utf8(&urlencoded).map_err(|_| {
@@ -597,12 +586,9 @@ pub async fn access_token<S: Into<String>>(
 pub async fn bearer_token(con_token: &KeyPair) -> Result<Token> {
     let content = "application/x-www-form-urlencoded;charset=UTF-8";
 
-    let auth_header = bearer_request(con_token);
-    let request = Request::post(links::auth::BEARER_TOKEN)
-        .header(AUTHORIZATION, auth_header)
-        .header(CONTENT_TYPE, content)
-        .body(Body::from("grant_type=client_credentials"))
-        .unwrap();
+    let request = RequestBuilder::new(Method::POST, links::auth::BEARER_TOKEN)
+        .with_body("grant_type=client_credentials", content)
+        .request_consumer_bearer(con_token);
 
     let decoded = request_with_json_response::<serde_json::Value>(request).await?;
     let result = decoded
@@ -634,13 +620,9 @@ pub async fn invalidate_bearer(con_token: &KeyPair, token: &Token) -> Result<Tok
 
     let content = "application/x-www-form-urlencoded;charset=UTF-8";
 
-    let auth_header = bearer_request(con_token);
-    let body = Body::from(format!("access_token={}", token));
-    let request = Request::post(links::auth::INVALIDATE_BEARER)
-        .header(AUTHORIZATION, auth_header)
-        .header(CONTENT_TYPE, content)
-        .body(body)
-        .unwrap();
+    let request = RequestBuilder::new(Method::POST, links::auth::INVALIDATE_BEARER)
+        .with_body(format!("access_token={}", token), content)
+        .request_consumer_bearer(con_token);
 
     let decoded = request_with_json_response::<serde_json::Value>(request).await?;
     let result = decoded

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -660,19 +660,3 @@ pub async fn verify_tokens(token: &Token) -> Result<Response<crate::user::Twitte
     let req = get(links::auth::VERIFY_CREDENTIALS, token, None);
     request_with_json_response(req).await
 }
-
-#[cfg(test)]
-mod tests {
-    use super::bearer_request;
-
-    #[test]
-    fn bearer_header() {
-        let con_key = "xvz1evFS4wEEPTGEFPHBog";
-        let con_secret = "L8qq9PZyRg6ieKGEKhZolGC0vJWLw8iEJ88DRdyOg";
-        let con_token = super::KeyPair::new(con_key, con_secret);
-
-        let output = bearer_request(&con_token);
-
-        assert_eq!(output, "Basic eHZ6MWV2RlM0d0VFUFRHRUZQSEJvZzpMOHFxOVBaeVJnNmllS0dFS2hab2xHQzB2SldMdzhpRUo4OERSZHlPZw==");
-    }
-}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -198,7 +198,7 @@ use crate::{
 
 pub(crate) mod raw;
 
-use raw::*;
+use raw::RequestBuilder;
 
 /// A key/secret pair representing the app that is sending a request or an authorization from a user.
 ///

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -134,7 +134,7 @@ impl<'a> RequestBuilder<'a> {
 
 /// OAuth header set used to create an OAuth signature.
 #[derive(Clone, Debug)]
-pub struct OAuthParams {
+struct OAuthParams {
     /// The consumer key that represents the app making the API request.
     consumer_key: KeyPair,
     /// The token that represents the user authorizing the request (or the access request
@@ -179,7 +179,7 @@ impl OAuthParams {
     /// specifically for when you're generating a request token; otherwise it should be the request
     /// token (for when you're generating an access token) or an access token (for when you're
     /// requesting a regular API function).
-    pub fn from_keys(consumer_key: KeyPair, token: Option<KeyPair>) -> OAuthParams {
+    fn from_keys(consumer_key: KeyPair, token: Option<KeyPair>) -> OAuthParams {
         OAuthParams {
             consumer_key,
             token,
@@ -197,7 +197,7 @@ impl OAuthParams {
 
     /// Uses the parameters in this `OAuthParams` instance to generate a signature for the given
     /// request, returning it as a `SignedHeader`.
-    pub(crate) fn sign_request(self, method: Method, uri: &str, params: Option<&ParamList>) -> SignedHeader {
+    fn sign_request(self, method: Method, uri: &str, params: Option<&ParamList>) -> SignedHeader {
         let query_string = {
             let sig_params = params
                 .cloned()
@@ -268,7 +268,7 @@ impl OAuthParams {
 
 /// Represents an "addon" to an OAuth header.
 #[derive(Clone, Debug)]
-pub enum OAuthAddOn {
+enum OAuthAddOn {
     /// An `oauth_callback` parameter, used when generating a request token.
     Callback(String),
     /// An `oauth_verifier` parameter, used when generating an access token.
@@ -298,7 +298,7 @@ impl OAuthAddOn {
 
 /// A set of `OAuthParams` parameters combined with a request signature, ready to be attached to a
 /// request.
-pub struct SignedHeader {
+struct SignedHeader {
     /// The OAuth parameters used to create the signature.
     params: BTreeMap<&'static str, Cow<'static, str>>,
 }
@@ -332,7 +332,7 @@ impl fmt::Display for SignedHeader {
 /// The authorization created by this function can only be used with requests to generate or
 /// invalidate a bearer token. Using this authorization with any other endpoint will result in an
 /// invalid request.
-pub fn bearer_request(con_token: &KeyPair) -> String {
+fn bearer_request(con_token: &KeyPair) -> String {
     let text = format!("{}:{}", con_token.key, con_token.secret);
     format!("Basic {}", base64::encode(&text))
 }

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -357,3 +357,19 @@ pub fn post_json<B: serde::Serialize>(uri: &str, token: &Token, body: B) -> Requ
 
     request.body(body).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::bearer_request;
+
+    #[test]
+    fn bearer_header() {
+        let con_key = "xvz1evFS4wEEPTGEFPHBog";
+        let con_secret = "L8qq9PZyRg6ieKGEKhZolGC0vJWLw8iEJ88DRdyOg";
+        let con_token = super::KeyPair::new(con_key, con_secret);
+
+        let output = bearer_request(&con_token);
+
+        assert_eq!(output, "Basic eHZ6MWV2RlM0d0VFUFRHRUZQSEJvZzpMOHFxOVBaeVJnNmllS0dFS2hab2xHQzB2SldMdzhpRUo4OERSZHlPZw==");
+    }
+}

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -13,7 +13,6 @@ use base64;
 use hmac::{Hmac, Mac};
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
 use hyper::{Body, Method, Request};
-use percent_encoding::{utf8_percent_encode, AsciiSet, PercentEncode};
 use rand::{self, Rng};
 use sha1::Sha1;
 
@@ -21,23 +20,6 @@ use crate::common::*;
 
 use super::{Token, KeyPair};
 
-/// Percent-encodes the given string based on the Twitter API specification.
-///
-/// Twitter bases its encoding scheme on RFC 3986, Section 2.1. They describe the process in full
-/// [in their documentation][twitter-percent], but the process can be summarized by saying that
-/// every *byte* that is not an ASCII number or letter, or the ASCII characters `-`, `.`, `_`, or
-/// `~` must be replaced with a percent sign (`%`) and the byte value in hexadecimal.
-///
-/// [twitter-percent]: https://developer.twitter.com/en/docs/basics/authentication/oauth-1-0a/percent-encoding-parameters
-///
-/// When this function was originally implemented, the `percent_encoding` crate did not have an
-/// encoding set that matched this, so it was recreated here.
-pub fn percent_encode(src: &str) -> PercentEncode {
-    lazy_static::lazy_static! {
-        static ref ENCODER: AsciiSet = percent_encoding::NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
-    }
-    utf8_percent_encode(src, &*ENCODER)
-}
 
 /// OAuth header set used to create an OAuth signature.
 #[derive(Clone, Debug)]

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -187,28 +187,6 @@ impl OAuthParams {
         }
     }
 
-    /// Adds the given callback to this `OAuthParams` header.
-    ///
-    /// Note that the `callback` and `verifier` parameters are mutually exclusive. If you call this
-    /// function after setting a verifier with `with_verifier`, it will overwrite the verifier.
-    pub fn with_callback(self, callback: String) -> OAuthParams {
-        OAuthParams {
-            addon: OAuthAddOn::Callback(callback),
-            ..self
-        }
-    }
-
-    /// Adds the given verifier to this `OAuthParams` header.
-    ///
-    /// Note that the `callback` and `verifier` parameters are mutually exclusive. If you call this
-    /// function after setting a callback with `with_callback`, it will overwrite the callback.
-    pub fn with_verifier(self, verifier: String) -> OAuthParams {
-        OAuthParams {
-            addon: OAuthAddOn::Verifier(verifier),
-            ..self
-        }
-    }
-
     /// Adds the given callback or verifier to this `OAuthParams` header.
     fn with_addon(self, addon: OAuthAddOn) -> OAuthParams {
         OAuthParams {

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -20,7 +20,11 @@ use crate::common::*;
 
 use super::{Token, KeyPair};
 
+// n.b. this type is exported in `raw::auth` - these docs are public!
 /// Builder struct to assemble and sign an API request.
+///
+/// For more information about how to use this type and about building requests manually, see [the
+/// module docs](index.html).
 pub struct RequestBuilder<'a> {
     base_uri: &'a str,
     method: Method,

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -108,6 +108,10 @@ impl<'a> RequestBuilder<'a> {
         }
     }
 
+    pub fn request_consumer_bearer(self, consumer_key: &KeyPair) -> Request<Body> {
+        self.request_authorization(bearer_request(consumer_key))
+    }
+
     fn request_authorization(self, authorization: String) -> Request<Body> {
         let full_url = if let Some(query) = self.query {
             format!("{}?{}", self.base_uri, query)

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -349,50 +349,6 @@ impl fmt::Display for SignedHeader {
     }
 }
 
-/// An abstracted set of authorization credentials.
-///
-/// This enum is constructed from a `Token` and either constructs an OAuth signature or a Bearer
-/// signature based on what kind of token is given. This allows the `auth` entry points to not need
-/// to match on the structure of a `Token` and instead just focus on signing the request.
-pub enum AuthHeader {
-    /// A set of OAuth parameters based on a consumer/access token combo.
-    AccessToken(OAuthParams),
-    /// A Bearer token.
-    Bearer(String),
-}
-
-impl From<Token> for AuthHeader {
-    fn from(token: Token) -> AuthHeader {
-        match token {
-            Token::Access { consumer, access } => {
-                AuthHeader::AccessToken(OAuthParams::from_keys(consumer, Some(access)))
-            }
-            Token::Bearer(b) => {
-                AuthHeader::Bearer(b)
-            }
-        }
-    }
-}
-
-impl AuthHeader {
-    /// With the given parameters, create an `Authorization` header that matches the `Token` that
-    /// was used to create this `AuthHeader`. The resulting string can be passed as an
-    /// `Authorization` header to an API request.
-    ///
-    /// If the source `Token` was a bearer token, this function ignores the parameters and gives a
-    /// Bearer authorization based on the original token.
-    pub(crate) fn sign_request(self, method: Method, uri: &str, params: Option<&ParamList>) -> String {
-        match self {
-            AuthHeader::AccessToken(oauth) => {
-                oauth.sign_request(method, uri, params).to_string()
-            }
-            AuthHeader::Bearer(b) => {
-                format!("Bearer {}", b)
-            }
-        }
-    }
-}
-
 /// Creates a basic `Authorization` header based on the given consumer token.
 ///
 /// The authorization created by this function can only be used with requests to generate or

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -215,6 +215,22 @@ impl ParamList {
             list::ListID::ID(id) => self.add_param("list_id", id.to_string()),
         }
     }
+
+    /// Merge the parameters from the given `ParamList` into this one.
+    pub(crate) fn combine(&mut self, other: ParamList) {
+        self.0.extend(other.0);
+    }
+
+    /// Renders this `ParamList` as an `application/x-www-form-urlencoded` string.
+    ///
+    /// The key/value pairs are printed as `key1=value1&key2=value2`, with all keys and values
+    /// being percent-encoded according to Twitter's requirements.
+    pub fn to_urlencoded(&self) -> String {
+        self.0.iter()
+            .map(|(k, v)| format!("{}={}", percent_encode(k), percent_encode(v)))
+            .collect::<Vec<_>>()
+            .join("&")
+    }
 }
 
 // Helper trait to stringify the contents of an Option

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -96,6 +96,7 @@ use std::pin::Pin;
 use chrono::{self, TimeZone};
 use hyper::header::{HeaderMap, HeaderValue};
 use mime;
+use percent_encoding::{utf8_percent_encode, AsciiSet, PercentEncode};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
@@ -368,6 +369,24 @@ where
 {
     let str = String::deserialize(ser)?;
     str.parse().map_err(|e| D::Error::custom(e))
+}
+
+/// Percent-encodes the given string based on the Twitter API specification.
+///
+/// Twitter bases its encoding scheme on RFC 3986, Section 2.1. They describe the process in full
+/// [in their documentation][twitter-percent], but the process can be summarized by saying that
+/// every *byte* that is not an ASCII number or letter, or the ASCII characters `-`, `.`, `_`, or
+/// `~` must be replaced with a percent sign (`%`) and the byte value in hexadecimal.
+///
+/// [twitter-percent]: https://developer.twitter.com/en/docs/basics/authentication/oauth-1-0a/percent-encoding-parameters
+///
+/// When this function was originally implemented, the `percent_encoding` crate did not have an
+/// encoding set that matched this, so it was recreated here.
+pub fn percent_encode(src: &str) -> PercentEncode {
+    lazy_static::lazy_static! {
+        static ref ENCODER: AsciiSet = percent_encoding::NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+    }
+    utf8_percent_encode(src, &*ENCODER)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #32

This PR is the culmination of the work from #91 and #93. When i started egg-mode, i swore up and down that i didn't want to expose a generic OAuth mechanism, but while i was working on the `raw` module and the `auth` refactor, i noticed i could create something that was both easy-to-use and useful to the people who needed to use egg-mode for purposes we hadn't allowed or envisioned. I don't really want to extract this into its own crate unless people really want it for something other than Twitter, since i don't want to create the extra dependency for seemingly no reason.

As with everything i add to egg-mode, i tried to write compelling documentation to describe how to use it effectively. Part of the design of `RequestBuilder` was informed by my existing use of the auth internals, as well as looking at endpoints i hadn't bound yet or couldn't access, like [`PUT direct_messages/welcome_messages/update`](https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/update-welcome-message) or the [Enterprise APIs requiring Basic Authentication](https://developer.twitter.com/en/docs/basics/authentication/basic-auth).

Like with my last couple PRs, i'm going to leave this up for a day or so, then revisit it for any final tweaks before merging. I'll probably want to cut a release after this lands, to make it available for people to use more easily.