### PR TITLE
update hyper-rustls and enable webpki-roots via crate features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   - New type `ParamList` to represent a list of parameters to an API call
   - New `raw` example showing how to pull the raw JSON from fetching a tweet
 - `RateLimit` is now an exposed type with its own docs
+- The optional dependency `hyper-rustls` has been upgraded to 0.20, and two new egg-mode crate
+  features were added to affect how it loads root certificates: `rustls` will use
+  `rustls-native-certs` to load certificates from the operating system, while `rustls_webpki` will
+  use the `webpki-roots` crate to compile in Mozilla's root certificates for use by `rustls`.
+  - This is a **breaking change** if you were using the previous `hyper-rustls` feature, since the
+    crate is now loaded without default features by itself
 
 ### Changed
 - The repository has moved! egg-mode's new home is now at `egg-mode-rs/egg-mode`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 derive_more = "0.99"
 hmac = "0.7"
 hyper = "0.13"
-hyper-rustls = { version = "0.19", optional = true }
+hyper-rustls = { version = "0.20", optional = true, default-features = false }
 hyper-tls = { version = "0.4", optional = true }
 lazy_static = "1.4"
 native-tls = { version = "0.2", optional = true }
@@ -39,6 +39,8 @@ url = "2.1.1"
 [features]
 default = ["native_tls"]
 native_tls = ["native-tls", "hyper-tls"]
+rustls = ["hyper-rustls", "hyper-rustls/native-tokio"]
+rustls_webpki = ["hyper-rustls", "hyper-rustls/webpki-tokio"]
 
 [dev-dependencies]
 yansi = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,25 @@
 //! # }
 //! ```
 //!
+//! # Crate features
+//!
+//! While all of egg-mode's features are available by default, it allows you to configure how it
+//! connects to Twitter and how it uses HTTPS. The crate's Cargo features are the following:
+//!
+//! * `native_tls`: On by default. With this feature on, egg-mode uses `native-tls` to access your
+//!   operating system's native TLS functionality to access Twitter.
+//! * `rustls`: Off by default. With this feature on, egg-mode instead uses the `rustls` TLS stack
+//!   to access Twitter. `rustls` will still use your operating system's native root certificates
+//!   to verify the connection.
+//! * `rustls_webpki`: Off by default. With this feature on, egg-mode will also use `rustls` to
+//!   connect, but it will also use the `webpki-roots` crate to include a set of compiled-in root
+//!   certificates to verify the connection, instead of using your operating system's root
+//!   certificates.
+//!
+//! Keep in mind that these features are mutually exclusive - if you enable more than one, a
+//! compile error will result. If you need to use `rustls` or `rustls_webpki`, remember to set
+//! `default-features = false` in your Cargo.toml.
+//!
 //! # Types and Functions
 //!
 //! All of the main content of egg-mode is in submodules, but there are a few things here in the


### PR DESCRIPTION
Closes #92

This PR updates `hyper-rustls` to allow for exposing its `native-tokio` and `webpki-tokio` features, as egg-mode features `rustls` and `rustls_webpki`, respectively. This does break existing rustls users, since the feature will need to be renamed from `hyper-rustls` to `rustls`, but i felt like it was necessary to allow for the webpki roots to be accessed.

I ran an example locally with all three configurations (the previously mentioned `rustls` configurations and the existing `native_tls` option) and they all seemed to work on my system. Hopefully this can help people who are in a similar situation as in #92.