### PR TITLE
overhaul the `direct` module to use the new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog for egg-mode
 
+## Pending
+
+### Changed
+- The `direct` module has been overhauled to switch it over to the DM Events API
+  - `sent` and `received` have been merged into `list`, to match the endpoint
+  - `send` has been changed into the `DraftMessage` type, to reflect the new capabilities
+    - A new function `media::upload_media_for_dm` is available to upload media specifically for a
+      Direct Message
+  - The `DirectMessage` type no longer contains sender/recipient info other than IDs, as they're no
+    longer returned by Twitter
+    - However, it does contain new fields to reflect the new capabilities
+    - The new types `QuickReply` and `Cta` have been introduced to express those respective
+      capabilities
+  - `delete` no longer returns any information on success, as Twitter no longer returns anything
+    itself
+  - `conversations` and `ConversationsTimeline` have been removed, since the biggest work they did
+    is now done by Twitter
+    - They've been replaced by `into_conversations` on the new `Timeline` type
+    - The `conversations` example has been updated to demonstrate the new API
+  - This is technically a **breaking change**, but the old DMs stuff hasn't worked since 2018 so it
+    was already broken without this change
+
+### Added
+- New function `raw::request_delete` which is like `request_get`, but sends a DELETE request instead
+- New function `Response::try_map`, to change the type of a `Response` using a fallible conversion
+- `Response` now implements `IntoIterator` if its contained type does
+  - A new type `ResponseIter` has been introduced to contain this iterator
+
 ## [0.15.0] - 2020-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Added
 - New function `raw::request_delete` which is like `request_get`, but sends a DELETE request instead
+- New module `raw::types::direct`, containing raw `Deserialize`able types used with the Direct
+  Message API
 - New function `Response::try_map`, to change the type of a `Response` using a fallible conversion
 - `Response` now implements `IntoIterator` if its contained type does
   - A new type `ResponseIter` has been introduced to contain this iterator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - New module `raw::types::direct`, containing raw `Deserialize`able types used with the Direct
   Message API
 - New function `Response::try_map`, to change the type of a `Response` using a fallible conversion
+- New function `Response::into`, to convert a `Response` using the `Into` trait
 - `Response` now implements `IntoIterator` if its contained type does
   - A new type `ResponseIter` has been introduced to contain this iterator
 

--- a/examples/conversations.rs
+++ b/examples/conversations.rs
@@ -2,23 +2,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::collections::HashMap;
+
 mod common;
 
 #[tokio::main]
 async fn main() {
     let c = common::Config::load().await;
 
-    let convos = egg_mode::direct::conversations(&c.token);
-    let convos = convos.newest().await.unwrap();
+    let convos = egg_mode::direct::list(&c.token).into_conversations().await.unwrap();
+    let mut users = HashMap::new();
 
-    for (id, convo) in &convos.conversations {
+    for (id, convo) in &convos {
         let user = egg_mode::user::show(*id, &c.token).await.unwrap();
         println!("-----");
         println!("Conversation with @{}:", user.screen_name);
         for msg in convo {
+            if !users.contains_key(&msg.sender_id) {
+                let sender = egg_mode::user::show(msg.sender_id, &c.token).await.unwrap();
+                users.insert(msg.sender_id, sender);
+            }
+            let sender = &users[&msg.sender_id];
             println!(
                 "--@{} sent at {}:",
-                msg.sender_screen_name,
+                sender.screen_name,
                 msg.created_at.with_timezone(&chrono::Local)
             );
             println!("    {}", msg.text);

--- a/src/auth/raw.rs
+++ b/src/auth/raw.rs
@@ -424,6 +424,20 @@ pub fn get(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body
 }
 
 // n.b. this function is re-exported in the `raw` module - these docs are public!
+/// Assemble a signed DELETE request to the given URL with the given parameters.
+///
+/// The given parameters, if present, will be appended to the given `uri` as a percent-encoded
+/// query string. If the given `token` is not a Bearer token, the parameters will also be used to
+/// create the OAuth signature.
+pub fn delete(uri: &str, token: &Token, params: Option<&ParamList>) -> Request<Body> {
+    let mut request = RequestBuilder::new(Method::DELETE, uri);
+    if let Some(params) = params {
+        request = request.with_query_params(params);
+    }
+    request.request_token(token)
+}
+
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Assemble a signed POST request to the given URL with the given parameters.
 ///
 /// The given parameters, if present, will be percent-encoded and included in the POST body

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -387,6 +387,16 @@ where
     str.parse().map_err(|e| D::Error::custom(e))
 }
 
+pub fn deser_from_string<'de, D, T>(ser: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    let str = String::deserialize(ser)?;
+    str.parse().map_err(|e| D::Error::custom(e))
+}
+
 /// Percent-encodes the given string based on the Twitter API specification.
 ///
 /// Twitter bases its encoding scheme on RFC 3986, Section 2.1. They describe the process in full

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -327,47 +327,6 @@ where
     }
 }
 
-pub fn merge_by<Iter, Fun>(left: Iter, right: Iter, comp: Fun) -> MergeBy<Iter::IntoIter, Fun>
-where
-    Iter: IntoIterator,
-    Fun: FnMut(&Iter::Item, &Iter::Item) -> bool,
-{
-    MergeBy {
-        left: left.into_iter().peekable(),
-        right: right.into_iter().peekable(),
-        comp: comp,
-        fused: None,
-    }
-}
-
-pub fn max_opt<T: PartialOrd>(left: Option<T>, right: Option<T>) -> Option<T> {
-    match (left, right) {
-        (Some(left), Some(right)) => {
-            if left >= right {
-                Some(left)
-            } else {
-                Some(right)
-            }
-        }
-        (left, None) => left,
-        (None, right) => right,
-    }
-}
-
-pub fn min_opt<T: PartialOrd>(left: Option<T>, right: Option<T>) -> Option<T> {
-    match (left, right) {
-        (Some(left), Some(right)) => {
-            if left <= right {
-                Some(left)
-            } else {
-                Some(right)
-            }
-        }
-        (left, None) => left,
-        (None, right) => right,
-    }
-}
-
 pub fn deserialize_datetime<'de, D>(ser: D) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -89,9 +89,9 @@ impl<T> Response<T> {
     ///
     ///Note that this is not a member function, so as to not conflict with potential methods on the
     ///contained `T`.
-    pub fn try_map<F, U>(src: Response<T>, fun: F) -> Result<Response<U>>
+    pub fn try_map<F, U, E>(src: Response<T>, fun: F) -> std::result::Result<Response<U>, E>
     where
-        F: FnOnce(T) -> Result<U>
+        F: FnOnce(T) -> std::result::Result<U, E>
     {
         Ok(Response {
             rate_limit_status: src.rate_limit_status,

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -181,6 +181,18 @@ pub async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
 }
 
 // n.b. this function is re-exported in the `raw` module - these docs are public!
+/// Loads the given request and discards the response body after parsing it for rate-limit and
+/// error information, returning the rate-limit information from the headers.
+pub async fn request_with_empty_response(request: Request<Body>) -> Result<Response<()>> {
+    let (headers, _) = raw_request(request).await?;
+    let rate_limit_status = RateLimit::try_from(&headers)?;
+    Ok(Response {
+        rate_limit_status,
+        response: (),
+    })
+}
+
+// n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Loads the given request and parses the response as JSON into the given type, including
 /// rate-limit headers.
 pub async fn request_with_json_response<T: DeserializeOwned>(

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -98,6 +98,23 @@ impl<T> Response<T> {
             response: fun(src.response)?,
         })
     }
+
+    /// Converts a `Response<T>` into a `Response<U>` using the `Into` trait.
+    ///
+    /// This is implemented as a type function instead of the `From`/`Into` trait due to
+    /// implementation conflicts with the `From<T> for T` implementation in the standard library.
+    /// It is also implemented as a function directly on the `Response` type instead of as a member
+    /// function to not clash with the `into()` function that would be available on the contained
+    /// `T`.
+    pub fn into<U>(src: Self) -> Response<U>
+    where
+        T: Into<U>,
+    {
+        Response {
+            rate_limit_status: src.rate_limit_status,
+            response: src.response.into(),
+        }
+    }
 }
 
 impl<T: IntoIterator> IntoIterator for Response<T> {

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -82,6 +82,22 @@ impl<T> Response<T> {
             response: fun(src.response),
         }
     }
+
+    ///Attempt to convert a `Response<T>` into a `Response<U>` by running its contained response
+    ///through the given function, preserving its rate-limit information. If the conversion
+    ///function fails, an error is returned instead.
+    ///
+    ///Note that this is not a member function, so as to not conflict with potential methods on the
+    ///contained `T`.
+    pub fn try_map<F, U>(src: Response<T>, fun: F) -> Result<Response<U>>
+    where
+        F: FnOnce(T) -> Result<U>
+    {
+        Ok(Response {
+            rate_limit_status: src.rate_limit_status,
+            response: fun(src.response)?,
+        })
+    }
 }
 
 // n.b. this function is re-exported in the `raw` module - these docs are public!

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -111,6 +111,11 @@ impl<T: IntoIterator> IntoIterator for Response<T> {
     }
 }
 
+/// Iterator wrapper around a `Response`.
+///
+/// This type is returned by `Response`'s `IntoIterator` implementation. It uses the `IntoIterator`
+/// implementation of the contained `T`, and copies the rate-limit information to yield individual
+/// `Response<T::Item>` instances.
 pub struct ResponseIter<T> {
     it: Response<T>,
 }

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -16,7 +16,7 @@ pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage
     let params = ParamList::default().add_param("id", id.to_string());
     let req = get(links::direct::SHOW, token, Some(&params));
     let resp: Response<raw::SingleEvent> = request_with_json_response(req).await?;
-    Ok(Response::map(resp, |ev| ev.into()))
+    Ok(Response::into(resp))
 }
 
 /// Load the list of direct messages sent and received by the authorized user.

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -18,7 +18,12 @@ pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage
     Response::try_map(resp, |ev| ev.try_into())
 }
 
-/// Load the first page of the list of direct messages sent and received by the authorized user.
+/// Load the list of direct messages sent and received by the authorized user.
+///
+/// This function will only return the messages sent and received in the last 30 days. For more
+/// information, see the docs for [`Timeline`].
+///
+/// [`Timeline`]: struct.Timeline.html
 pub fn list(token: &auth::Token) -> Timeline {
     Timeline::new(links::direct::LIST, token.clone())
 }

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -8,65 +8,67 @@ use crate::{auth, links};
 
 use super::*;
 
-///Lookup a single DM by its numeric ID.
+/// Lookup a single DM by its numeric ID.
 pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage>, error::Error> {
     let params = ParamList::default().add_param("id", id.to_string());
     let req = get(links::direct::SHOW, token, Some(&params));
-    request_with_json_response(req).await
+    let mut resp: Response<serde_json::Value> = request_with_json_response(req).await?;
+    let dm = serde_json::from_value(resp.response["event"].take())?;
+    Ok(Response::map(resp, |_| dm))
 }
 
-///Create a `Timeline` struct to navigate the direct messages received by the authenticated user.
-pub fn received(token: &auth::Token) -> Timeline {
-    Timeline::new(links::direct::RECEIVED, None, token)
-}
+/////Create a `Timeline` struct to navigate the direct messages received by the authenticated user.
+//pub fn received(token: &auth::Token) -> Timeline {
+//    Timeline::new(links::direct::RECEIVED, None, token)
+//}
 
-///Create a `Timeline` struct to navigate the direct messages sent by the authenticated user.
-pub fn sent(token: &auth::Token) -> Timeline {
-    Timeline::new(links::direct::SENT, None, token)
-}
+/////Create a `Timeline` struct to navigate the direct messages sent by the authenticated user.
+//pub fn sent(token: &auth::Token) -> Timeline {
+//    Timeline::new(links::direct::SENT, None, token)
+//}
 
-///Send a new direct message to the given user.
-///
-///The recipient must allow DMs from the authenticated user for this to be successful. In practice,
-///this means that the recipient must either follow the authenticated user, or they must have the
-///"allow DMs from anyone" setting enabled. As the latter setting has no visibility on the API,
-///there may be situations where you can't verify the recipient's ability to receive the requested
-///DM beforehand.
-///
-///Upon successfully sending the DM, the message will be returned.
-pub async fn send<T: Into<UserID>>(
-    to: T,
-    text: CowStr,
-    token: &auth::Token,
-) -> Result<Response<DirectMessage>, error::Error> {
-    let params = ParamList::new()
-        .add_user_param(to.into())
-        .add_param("text", text);
+/////Send a new direct message to the given user.
+/////
+/////The recipient must allow DMs from the authenticated user for this to be successful. In practice,
+/////this means that the recipient must either follow the authenticated user, or they must have the
+/////"allow DMs from anyone" setting enabled. As the latter setting has no visibility on the API,
+/////there may be situations where you can't verify the recipient's ability to receive the requested
+/////DM beforehand.
+/////
+/////Upon successfully sending the DM, the message will be returned.
+//pub async fn send<T: Into<UserID>>(
+//    to: T,
+//    text: CowStr,
+//    token: &auth::Token,
+//) -> Result<Response<DirectMessage>, error::Error> {
+//    let params = ParamList::new()
+//        .add_user_param(to.into())
+//        .add_param("text", text);
 
-    let req = post(links::direct::SEND, token, Some(&params));
+//    let req = post(links::direct::SEND, token, Some(&params));
 
-    request_with_json_response(req).await
-}
+//    request_with_json_response(req).await
+//}
 
-///Delete the direct message with the given ID.
-///
-///The authenticated user must be the sender of this DM for this call to be successful.
-///
-///On a successful deletion, the future returned by this function yields the freshly-deleted
-///message.
-pub async fn delete(id: u64, token: &auth::Token) -> Result<Response<DirectMessage>, error::Error> {
-    let params = ParamList::new().add_param("id", id.to_string());
-    let req = post(links::direct::DELETE, token, Some(&params));
-    request_with_json_response(req).await
-}
+/////Delete the direct message with the given ID.
+/////
+/////The authenticated user must be the sender of this DM for this call to be successful.
+/////
+/////On a successful deletion, the future returned by this function yields the freshly-deleted
+/////message.
+//pub async fn delete(id: u64, token: &auth::Token) -> Result<Response<DirectMessage>, error::Error> {
+//    let params = ParamList::new().add_param("id", id.to_string());
+//    let req = post(links::direct::DELETE, token, Some(&params));
+//    request_with_json_response(req).await
+//}
 
-///Create a `ConversationTimeline` loader that can load direct messages as a collection of
-///pre-sorted conversations.
-///
-///Note that this does not load any messages; you need to call `newest` or `next` for that. See
-///[`ConversationTimeline`] for details.
-///
-///[`ConversationTimeline`]: struct.ConversationTimeline.html
-pub fn conversations(token: &auth::Token) -> ConversationTimeline {
-    ConversationTimeline::new(token)
-}
+/////Create a `ConversationTimeline` loader that can load direct messages as a collection of
+/////pre-sorted conversations.
+/////
+/////Note that this does not load any messages; you need to call `newest` or `next` for that. See
+/////[`ConversationTimeline`] for details.
+/////
+/////[`ConversationTimeline`]: struct.ConversationTimeline.html
+//pub fn conversations(token: &auth::Token) -> ConversationTimeline {
+//    ConversationTimeline::new(token)
+//}

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -58,14 +58,3 @@ pub fn list(token: &auth::Token) -> Timeline {
 //    let req = post(links::direct::DELETE, token, Some(&params));
 //    request_with_json_response(req).await
 //}
-
-/////Create a `ConversationTimeline` loader that can load direct messages as a collection of
-/////pre-sorted conversations.
-/////
-/////Note that this does not load any messages; you need to call `newest` or `next` for that. See
-/////[`ConversationTimeline`] for details.
-/////
-/////[`ConversationTimeline`]: struct.ConversationTimeline.html
-//pub fn conversations(token: &auth::Token) -> ConversationTimeline {
-//    ConversationTimeline::new(token)
-//}

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -6,7 +6,6 @@ use crate::common::*;
 
 use std::convert::TryInto;
 
-use crate::user::UserID;
 use crate::{auth, links};
 
 use super::*;

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -4,7 +4,7 @@
 
 use crate::common::*;
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use crate::{auth, links};
 use crate::user::{self, UserID};
@@ -16,7 +16,7 @@ pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage
     let params = ParamList::default().add_param("id", id.to_string());
     let req = get(links::direct::SHOW, token, Some(&params));
     let resp: Response<raw::SingleEvent> = request_with_json_response(req).await?;
-    Response::try_map(resp, |ev| ev.try_into())
+    Ok(Response::map(resp, |ev| ev.into()))
 }
 
 /// Load the list of direct messages sent and received by the authorized user.

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -3,6 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::common::*;
+
+use std::convert::TryInto;
+
 use crate::user::UserID;
 use crate::{auth, links};
 
@@ -12,9 +15,8 @@ use super::*;
 pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage>, error::Error> {
     let params = ParamList::default().add_param("id", id.to_string());
     let req = get(links::direct::SHOW, token, Some(&params));
-    let mut resp: Response<serde_json::Value> = request_with_json_response(req).await?;
-    let dm = serde_json::from_value(resp.response["event"].take())?;
-    Ok(Response::map(resp, |_| dm))
+    let resp: Response<raw::SingleEvent> = request_with_json_response(req).await?;
+    Response::try_map(resp, |ev| ev.try_into())
 }
 
 /////Create a `Timeline` struct to navigate the direct messages received by the authenticated user.

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -4,8 +4,6 @@
 
 use crate::common::*;
 
-use std::convert::TryFrom;
-
 use crate::{auth, links};
 use crate::user::{self, UserID};
 
@@ -41,12 +39,7 @@ pub fn list(token: &auth::Token) -> Timeline {
 pub async fn delete(id: u64, token: &auth::Token) -> Result<Response<()>, error::Error> {
     let params = ParamList::new().add_param("id", id.to_string());
     let req = auth::raw::delete(links::direct::DELETE, token, Some(&params));
-    let (headers, _) = raw_request(req).await?;
-    let rate_limit_status = RateLimit::try_from(&headers)?;
-    Ok(Response {
-        rate_limit_status,
-        response: (),
-    })
+    request_with_empty_response(req).await
 }
 
 /// Marks the given message as read in the sender's interface.
@@ -76,12 +69,7 @@ pub async fn mark_read(
         .add_param("last_read_event_id", id.to_string())
         .add_param("recipient_id", recipient_id.to_string());
     let req = post(links::direct::MARK_READ, token, Some(&params));
-    let (headers, _) = raw_request(req).await?;
-    let rate_limit_status = RateLimit::try_from(&headers)?;
-    Ok(Response {
-        rate_limit_status,
-        response: (),
-    })
+    request_with_empty_response(req).await
 }
 
 /// Displays a visual typing indicator for the recipient.
@@ -112,10 +100,5 @@ pub async fn indicate_typing(
 
     let params = ParamList::new().add_param("recipient_id", recipient_id.to_string());
     let req = post(links::direct::INDICATE_TYPING, token, Some(&params));
-    let (headers, _) = raw_request(req).await?;
-    let rate_limit_status = RateLimit::try_from(&headers)?;
-    Ok(Response {
-        rate_limit_status,
-        response: (),
-    })
+    request_with_empty_response(req).await
 }

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -20,21 +20,9 @@ pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage
 }
 
 /// Load the first page of the list of direct messages sent and received by the authorized user.
-pub async fn list(token: &auth::Token) -> Result<Response<Vec<DirectMessage>>, error::Error> {
-    let req = get(links::direct::LIST, token, None);
-    let resp: Response<raw::EventCursor> = request_with_json_response(req).await?;
-    Response::try_map(resp, |evs| evs.try_into())
+pub fn list(token: &auth::Token) -> Timeline {
+    Timeline::new(links::direct::LIST, token.clone())
 }
-
-/////Create a `Timeline` struct to navigate the direct messages received by the authenticated user.
-//pub fn received(token: &auth::Token) -> Timeline {
-//    Timeline::new(links::direct::RECEIVED, None, token)
-//}
-
-/////Create a `Timeline` struct to navigate the direct messages sent by the authenticated user.
-//pub fn sent(token: &auth::Token) -> Timeline {
-//    Timeline::new(links::direct::SENT, None, token)
-//}
 
 /////Send a new direct message to the given user.
 /////

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -23,29 +23,6 @@ pub fn list(token: &auth::Token) -> Timeline {
     Timeline::new(links::direct::LIST, token.clone())
 }
 
-/////Send a new direct message to the given user.
-/////
-/////The recipient must allow DMs from the authenticated user for this to be successful. In practice,
-/////this means that the recipient must either follow the authenticated user, or they must have the
-/////"allow DMs from anyone" setting enabled. As the latter setting has no visibility on the API,
-/////there may be situations where you can't verify the recipient's ability to receive the requested
-/////DM beforehand.
-/////
-/////Upon successfully sending the DM, the message will be returned.
-//pub async fn send<T: Into<UserID>>(
-//    to: T,
-//    text: CowStr,
-//    token: &auth::Token,
-//) -> Result<Response<DirectMessage>, error::Error> {
-//    let params = ParamList::new()
-//        .add_user_param(to.into())
-//        .add_param("text", text);
-
-//    let req = post(links::direct::SEND, token, Some(&params));
-
-//    request_with_json_response(req).await
-//}
-
 /////Delete the direct message with the given ID.
 /////
 /////The authenticated user must be the sender of this DM for this call to be successful.

--- a/src/direct/fun.rs
+++ b/src/direct/fun.rs
@@ -19,6 +19,13 @@ pub async fn show(id: u64, token: &auth::Token) -> Result<Response<DirectMessage
     Response::try_map(resp, |ev| ev.try_into())
 }
 
+/// Load the first page of the list of direct messages sent and received by the authorized user.
+pub async fn list(token: &auth::Token) -> Result<Response<Vec<DirectMessage>>, error::Error> {
+    let req = get(links::direct::LIST, token, None);
+    let resp: Response<raw::EventCursor> = request_with_json_response(req).await?;
+    Response::try_map(resp, |evs| evs.try_into())
+}
+
 /////Create a `Timeline` struct to navigate the direct messages received by the authenticated user.
 //pub fn received(token: &auth::Token) -> Timeline {
 //    Timeline::new(links::direct::RECEIVED, None, token)

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -30,6 +30,10 @@
 //! * `show`: This allows you to load a single DM from its ID.
 //! * `delete`: This allows you to delete a DM from a user's own views. Note that it will not
 //!   delete it entirely from the system; the recipient will still have a copy of the message.
+//! * `mark_read`: This sends a read receipt for a given message to a given user. This also has the
+//!   effect of clearing the message's "unread" status for the authenticated user.
+//! * `indicate_typing`: This sends a typing indicator to a given user, to indicate that the
+//!   authenticated user is typing or thinking of a response.
 
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -102,7 +102,7 @@ impl TryFrom<raw::SingleEvent> for DirectMessage {
 
     fn try_from(ev: raw::SingleEvent) -> error::Result<DirectMessage> {
         let raw::SingleEvent { event, apps } = ev;
-        let raw: raw::RawDirectMessage = event.as_message_create().into();
+        let raw: raw::RawDirectMessage = event.as_raw_dm();
         raw.into_dm(&apps)
     }
 }
@@ -115,7 +115,7 @@ impl TryFrom<raw::EventCursor> for Vec<DirectMessage> {
         let mut ret = vec![];
 
         for ev in events {
-            let raw: raw::RawDirectMessage = ev.as_message_create().into();
+            let raw: raw::RawDirectMessage = ev.as_raw_dm();
             ret.push(raw.into_dm(&apps)?);
         }
 

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -40,6 +40,14 @@ pub struct DirectMessage {
     pub entities: DMEntities,
     /// An image, gif, or video attachment, if present.
     pub attachment: Option<entities::MediaEntity>,
+    /// A list of "call to action" buttons attached to the DM, if present.
+    pub ctas: Option<Vec<Cta>>,
+    /// A list of "Quick Replies" sent with this message to request structured input from the other
+    /// user.
+    pub quick_replies: Option<Vec<QuickReply>>,
+    /// The `metadata` accompanying a Quick Reply, if the other user selected a Quick Reply for
+    /// their response.
+    pub quick_reply_response: Option<String>,
     /// The ID of the user who sent the DM.
     pub sender_id: u64,
     /// The ID of the user who received the DM.
@@ -75,8 +83,11 @@ impl<'de> Deserialize<'de> for DirectMessage {
             text: raw.text,
             entities: raw.entities,
             attachment: raw.attachment,
+            ctas: raw.ctas,
             sender_id: raw.sender_id,
             recipient_id: raw.recipient_id,
+            quick_replies: raw.quick_replies,
+            quick_reply_response: raw.quick_reply_response,
         })
     }
 }
@@ -101,6 +112,30 @@ pub struct DMEntities {
     pub urls: Vec<entities::UrlEntity>,
     /// Collection of user mentions parsed from the DM.
     pub user_mentions: Vec<entities::MentionEntity>,
+}
+
+/// A "call to action" added as a button to a direct message.
+#[derive(Debug, Deserialize)]
+pub struct Cta {
+    /// The label shown to the user for the CTA.
+    pub label: String,
+    /// The `t.co` URL that the user should navigate to if they click this CTA.
+    pub tco_url: String,
+    /// The URL given for the CTA, that could be displayed if needed.
+    pub url: String,
+}
+
+/// A Quick Reply attached to a message to request structured input from a user.
+#[derive(Debug, Deserialize)]
+pub struct QuickReply {
+    /// The label shown to the user. When the user selects this Quick Reply, the label will be sent
+    /// as the `text` of the reply message.
+    pub label: String,
+    /// An optional description that accompanies a Quick Reply.
+    pub description: Option<String>,
+    /// Metadata that accompanies this Quick Reply. Metadata is not shown to the user, but is
+    /// available in the `quick_reply_response` when the user selects it.
+    pub metadata: String,
 }
 
 ///// Helper struct to navigate collections of direct messages by requesting DMs older or newer than

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -248,188 +248,65 @@ impl Timeline {
             }
         }).map_ok(|page| stream::iter(page).map(Ok::<_, error::Error>)).try_flatten()
     }
+
+    /// Loads all the direct messages from this `Timeline` and sorts them into a `DMConversations`
+    /// map.
+    ///
+    /// This adapter is a convenient way to sort all of a user's messages (from the last 30 days)
+    /// into a familiar user-interface pattern of a list of conversations between the authenticated
+    /// user and a specific other user. This function first pulls all the available messages, then
+    /// sorts them into a set of threads by matching them against which user the authenticated user
+    /// is messaging.
+    pub async fn into_conversations(self) -> Result<DMConversations, error::Error> {
+        let dms: Vec<DirectMessage> = self.into_stream().map_ok(|r| r.response).try_collect().await?;
+        let mut conversations = HashMap::new();
+        let me_id = if let Some(dm) = dms.first() {
+            if dm.source_app.is_some() {
+                // since the source app info is only populated when the authenticated user sent the
+                // message, we know that this message was sent by the authenticated user
+                //
+                // TODO: is this a valid assumption? i can see this shooting me in the foot in the
+                // future
+                dm.sender_id
+            } else {
+                dm.recipient_id
+            }
+        } else {
+            // no messages, nothing to sort
+            return Ok(conversations);
+        };
+
+        for dm in dms {
+            let entry = match (dm.sender_id == me_id, dm.recipient_id == me_id) {
+                (true, true) => {
+                    // if the sender and recipient are the same - and they match the authenticated
+                    // user - then it's the listing of "messages to self"
+                    conversations.entry(me_id).or_default()
+                }
+                (true, false) => {
+                    conversations.entry(dm.recipient_id).or_default()
+                }
+                (false, true) => {
+                    conversations.entry(dm.sender_id).or_default()
+                }
+                (false, false) => {
+                    return Err(error::Error::InvalidResponse(
+                            "messages activity contains disjoint conversations",
+                            None));
+                }
+            };
+            entry.push(dm);
+        }
+
+        Ok(conversations)
+    }
 }
 
-/////Wrapper around a collection of direct messages, sorted by their recipient.
-/////
-/////The mapping exposed here is from a User ID to a listing of direct messages between the
-/////authenticated user and that user. For more information, see the docs for [`ConversationTimeline`].
-/////
-/////[`ConversationTimeline`]: struct.ConversationTimeline.html
-//pub type DMConversations = HashMap<u64, Vec<DirectMessage>>;
-
-/////Load the given set of conversations into this set.
-//fn merge(this: &mut DMConversations, conversations: DMConversations) {
-//    for (id, convo) in conversations {
-//        let messages = this.entry(id).or_insert(Vec::new());
-//        let cap = convo.len() + messages.len();
-//        let old_convo = mem::replace(messages, Vec::with_capacity(cap));
-
-//        //ASSUMPTION: these conversation threads are disjoint
-//        if old_convo.first().map(|m| m.id).unwrap_or(0) > convo.first().map(|m| m.id).unwrap_or(0) {
-//            messages.extend(old_convo);
-//            messages.extend(convo);
-//        } else {
-//            messages.extend(convo);
-//            messages.extend(old_convo);
-//        }
-//    }
-//}
-
-///// Helper struct to load both sent and received direct messages, pre-sorting them into
-///// conversations by their recipient.
-/////
-///// This timeline loader is meant to get around a limitation of the direct message API endpoints:
-///// Twitter only gives endpoints to load all the messages *sent* by the authenticated user, or all
-///// the messages *received* by the authenticated user. However, the common user interface for DMs
-///// is to separate them by the other account in the conversation. This loader is a higher-level
-///// wrapper over the direct `sent` and `received` calls to achieve this interface without library
-///// users having to implement it themselves.
-/////
-///// Much like [`Timeline`], simply receiving a `ConversationTimeline` from `conversations` does not
-///// load any messages on its own. This is to allow setting the page size before loading the first
-///// batch of messages.
-/////
-///// [`Timeline`]: struct.Timeline.html
-/////
-///// `ConversationTimeline` keeps a cache of all the messages its loaded, and updates this during
-///// calls to Twitter. Any calls on this timeline that generate a `ConversationFuture` will take
-///// ownership of the `ConversationTimeline` so that it can update this cache. The Future will
-///// return the `ConversationTimeline` on success. To view the current cache, use the
-///// `conversations` field.
-/////
-///// There are two methods to load messages, and they operate by extending the cache by loading
-///// messages either older or newer than the extent of the cache.
-/////
-///// **NOTE**: Twitter has different API limitations for sent versus received messages. You can only
-///// load the most recent 200 *received* messages through the public API, but you can load up to 800
-///// *sent* messages. This can create some strange user-interface if a user has some old
-///// conversations, as they can only see their own side of the conversation this way. If you'd like
-///// to load as many messages as possible, both API endpoints have a per-call limit of 200. Setting
-///// the page size to 200 prior to loading messages allows you to use one function call to load a
-///// fairly-complete view of the user's conversations.
-/////
-///// # Example
-/////
-///// ```rust,no_run
-///// # use egg_mode::Token;
-///// # #[tokio::main]
-///// # async fn main() {
-///// # let token: Token = unimplemented!();
-///// let mut conversations = egg_mode::direct::conversations(&token);
-/////
-///// // newest() and oldest() consume the Timeline and give it back on success, so assign it back
-///// // when it's done
-///// conversations = conversations.newest().await.unwrap();
-/////
-///// for (id, convo) in &conversations.conversations {
-/////     let user = egg_mode::user::show(*id, &token).await.unwrap();
-/////     println!("Conversation with @{}", user.screen_name);
-/////     for msg in convo {
-/////         println!("<@{}> {}", msg.sender_screen_name, msg.text);
-/////     }
-///// }
-///// # }
-///// ```
-//pub struct ConversationTimeline {
-//    sent: Timeline,
-//    received: Timeline,
-//    ///The message ID of the most recent sent message in the current conversation set.
-//    pub last_sent: Option<u64>,
-//    ///The message ID of the most recent received message in the current conversation set.
-//    pub last_received: Option<u64>,
-//    ///The message ID of the oldest sent message in the current conversation set.
-//    pub first_sent: Option<u64>,
-//    ///The message ID of the oldest received message in the current conversation set.
-//    pub first_received: Option<u64>,
-//    ///The number of messages loaded per API call.
-//    pub count: u32,
-//    ///The conversation threads that have been loaded so far.
-//    pub conversations: DMConversations,
-//}
-
-//impl ConversationTimeline {
-//    fn new(token: &auth::Token) -> ConversationTimeline {
-//        ConversationTimeline {
-//            sent: sent(token),
-//            received: received(token),
-//            last_sent: None,
-//            last_received: None,
-//            first_sent: None,
-//            first_received: None,
-//            count: 20,
-//            conversations: HashMap::new(),
-//        }
-//    }
-
-//    fn merge(&mut self, sent: Vec<DirectMessage>, received: Vec<DirectMessage>) {
-//        self.last_sent = max_opt(self.last_sent, sent.first().map(|m| m.id));
-//        self.last_received = max_opt(self.last_received, received.first().map(|m| m.id));
-//        self.first_sent = min_opt(self.first_sent, sent.last().map(|m| m.id));
-//        self.first_received = min_opt(self.first_received, received.last().map(|m| m.id));
-
-//        let sender = sent.first().map(|m| m.sender_id);
-//        let receiver = received.first().map(|m| m.recipient_id);
-
-//        if let Some(me_id) = sender.or(receiver) {
-//            let mut new_convo = HashMap::new();
-
-//            for msg in merge_by(sent, received, |left, right| left.id > right.id) {
-//                let recipient = if msg.sender_id == me_id {
-//                    msg.recipient_id
-//                } else {
-//                    msg.sender_id
-//                };
-
-//                let thread = new_convo.entry(recipient).or_insert(Vec::new());
-//                thread.push(msg);
-//            }
-
-//            merge(&mut self.conversations, new_convo);
-//        }
-//    }
-
-//    ///Builder function to set the number of messages pulled in a single request.
-//    pub fn with_page_size(self, page_size: u32) -> ConversationTimeline {
-//        ConversationTimeline {
-//            count: page_size,
-//            ..self
-//        }
-//    }
-
-//    ///Load messages newer than the currently-loaded set, or the newset set if no messages have
-//    ///been loaded yet. The complete conversation set can be viewed from the `ConversationTimeline`
-//    ///after it is finished loading.
-//    pub async fn newest(self) -> Result<ConversationTimeline, error::Error> {
-//        let sent = self.sent.call(self.last_sent, None);
-//        let received = self.received.call(self.last_received, None);
-
-//        self.make_future(sent, received).await
-//    }
-
-//    ///Load messages older than the currently-loaded set, or the newest set if no messages have
-//    ///been loaded. The complete conversation set can be viewed from the `ConversationTimeline`
-//    ///after it is finished loading.
-//    pub fn next(self) -> impl Future<Output = Result<ConversationTimeline, error::Error>> {
-//        let sent = self.sent.call(None, self.first_sent);
-//        let received = self.received.call(None, self.first_received);
-
-//        self.make_future(sent, received)
-//    }
-
-//    async fn make_future<S, R>(
-//        mut self,
-//        sent: S,
-//        received: R,
-//    ) -> Result<ConversationTimeline, error::Error>
-//    where
-//        S: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
-//        R: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
-//    {
-//        let (sent, received) = futures::future::join(sent, received).await;
-//        let sent = sent?;
-//        let received = received?;
-//        self.merge(sent.response, received.response);
-//        Ok(self)
-//    }
-//}
+/// Wrapper around a collection of direct messages, sorted by their recipient.
+///
+/// The mapping exposed here is from a User ID to a listing of direct messages between the
+/// authenticated user and that user. It's returned by the `into_conversations` adapter on
+/// [`Timeline`].
+///
+/// [`Timeline`]: struct.Timeline.html
+pub type DMConversations = HashMap<u64, Vec<DirectMessage>>;

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -8,46 +8,7 @@
 //! access. Your app must be configured to have "read, write, and direct message" access to use any
 //! function in this module, even the read-only ones.
 //!
-//! Although the Twitter website and official apps display DMs as threads between the authenticated
-//! user and specific other users, the API does not expose them like this. Separate calls to
-//! `received` and `sent` are necessary to fully reconstruct a DM thread. You can partition on
-//! `sender_id`/`receiver_id` and sort by their `created_at` to weave the streams together.
-//!
-//! ## Types
-//!
-//! * `DirectMessage`/`DMEntities`: A single DM and its associated entities. The `DMEntities`
-//!   struct contains information about URLs, user mentions, and hashtags in the DM.
-//! * `Timeline`: Effectively the same as `tweet::Timeline`, but gives out `DirectMessage`s
-//!   instead.  Returned by functions that traverse collections of DMs.
-//! * `ConversationTimeline`/`DMConversations`: This struct and alias are part of the
-//!   "conversations" wrapper for loading direct messages into per-recipient threads.
-//!
-//! ## Functions
-//!
-//! ### Lookup
-//!
-//! These functions pull a user's DMs for viewing. `sent` and `received` can be cursored with
-//! sub-views like with tweets, so they return a `Timeline` instance that can be navigated at will.
-//!
-//! * `sent`
-//! * `received`
-//! * `show`
-//! * `conversations`
-//!
-//! ### Actions
-//!
-//! These functions are your basic write access to DMs. As a DM does not carry as much metadata as
-//! a tweet, the `send` action does not go through a builder struct like with `DraftTweet`.
-//!
-//! * `send`
-//! * `delete`
-
-#![deprecated(
-    since = "0.15",
-    note =
-        "the direct message endpoints used in this module are no longer in service, \
-        and this module has not been migrated over to the DM Events API"
-)]
+//! TODO: i'm in the process of rewriting this module, so things are gonna change here real fast
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -66,33 +27,23 @@ mod raw;
 
 pub use self::fun::*;
 
-///Represents a single direct message.
-///
-///As a DM has far less metadata than a regular tweet, the structure consequently contains far
-///fewer fields. The basic fields are `id`, `text`, `entities`, and `created_at`; everything else
-///either refers to the sender or receiver in some manner.
+/// Represents a single direct message.
 #[derive(Debug)]
 pub struct DirectMessage {
-    ///Numeric ID for this DM.
+    /// Numeric ID for this DM.
     pub id: u64,
-    ///UTC timestamp from when this DM was created.
+    /// UTC timestamp from when this DM was created.
     pub created_at: chrono::DateTime<chrono::Utc>,
-    ///The text of the DM.
+    /// The text of the DM.
     pub text: String,
-    ///Link, hashtag, and user mention information parsed out of the DM.
+    /// Link, hashtag, and user mention information parsed out of the DM.
     pub entities: DMEntities,
-    ///The screen name of the user who sent the DM.
-    pub sender_screen_name: String,
-    ///The ID of the user who sent the DM.
+    /// An image, gif, or video attachment, if present.
+    pub attachment: Option<entities::MediaEntity>,
+    /// The ID of the user who sent the DM.
     pub sender_id: u64,
-    ///Full information of the user who sent the DM.
-    pub sender: Box<user::TwitterUser>,
-    ///The screen name of the user who received the DM.
-    pub recipient_screen_name: String,
-    ///The ID of the user who received the DM.
+    /// The ID of the user who received the DM.
     pub recipient_id: u64,
-    ///Full information for the user who received the DM.
-    pub recipient: Box<user::TwitterUser>,
 }
 
 impl<'de> Deserialize<'de> for DirectMessage {
@@ -114,10 +65,8 @@ impl<'de> Deserialize<'de> for DirectMessage {
         for entity in &mut raw.entities.user_mentions {
             codepoints_to_bytes(&mut entity.range, &raw.text);
         }
-        if let Some(ref mut media) = raw.entities.media {
-            for entity in media.iter_mut() {
-                codepoints_to_bytes(&mut entity.range, &raw.text);
-            }
+        if let Some(ref mut media) = raw.attachment {
+            codepoints_to_bytes(&mut media.range, &raw.text);
         }
 
         Ok(DirectMessage {
@@ -125,419 +74,413 @@ impl<'de> Deserialize<'de> for DirectMessage {
             created_at: raw.created_at,
             text: raw.text,
             entities: raw.entities,
-            sender_screen_name: raw.sender_screen_name,
+            attachment: raw.attachment,
             sender_id: raw.sender_id,
-            sender: raw.sender,
-            recipient_screen_name: raw.recipient_screen_name,
             recipient_id: raw.recipient_id,
-            recipient: raw.recipient,
         })
     }
 }
 
-///Container for URL, hashtag, mention, and media information associated with a direct message.
+/// Container for URL, hashtag, and mention information associated with a direct message.
 ///
-///As far as entities are concerned, a DM can contain nearly everything a tweet can. The only thing
-///that isn't present here is the "extended media" that would be on the tweet's `extended_entities`
-///field. A user can attach a single picture to a DM via the Twitter website or official apps, so
-///if that is present, it will be available in `media`. (Note that the functionality to send
-///pictures through a DM is unavailable on the public API; only viewing them is possible.)
+/// As far as entities are concerned, a DM can contain nearly everything a tweet can. The only
+/// thing that isn't present here is the "extended media" that would be on the tweet's
+/// `extended_entities` field. A user can attach a single picture to a DM, but if that is present,
+/// it will be available in the `attachments` field of the original `DirectMessage` struct and not
+/// in the entities.
 ///
-///For all other fields, if the message contains no hashtags, financial symbols ("cashtags"),
-///links, or mentions, those corresponding fields will still be present, just empty.
+/// For all other fields, if the message contains no hashtags, financial symbols ("cashtags"),
+/// links, or mentions, those corresponding fields will be empty.
 #[derive(Debug, Deserialize)]
 pub struct DMEntities {
-    ///Collection of hashtags parsed from the DM.
+    /// Collection of hashtags parsed from the DM.
     pub hashtags: Vec<entities::HashtagEntity>,
-    ///Collection of financial symbols, or "cashtags", parsed from the DM.
+    /// Collection of financial symbols, or "cashtags", parsed from the DM.
     pub symbols: Vec<entities::HashtagEntity>,
-    ///Collection of URLs parsed from the DM.
+    /// Collection of URLs parsed from the DM.
     pub urls: Vec<entities::UrlEntity>,
-    ///Collection of user mentions parsed from the DM.
+    /// Collection of user mentions parsed from the DM.
     pub user_mentions: Vec<entities::MentionEntity>,
-    ///If the message contains any attached media, this contains a collection of media information
-    ///from it.
-    pub media: Option<Vec<entities::MediaEntity>>,
 }
 
-/// Helper struct to navigate collections of direct messages by requesting DMs older or newer than
-/// certain IDs.
-///
-/// Using a Timeline to navigate collections of DMs allows you to efficiently cursor through a
-/// collection and only load in the messages you need.
-///
-/// To begin, call a method that returns a `Timeline`, optionally set the page size, and call
-/// `start` to load the first page of results:
-///
-/// ```rust,no_run
-/// # use egg_mode::Token;
-/// # #[tokio::main]
-/// # async fn main() {
-/// # let token: Token = unimplemented!();
-/// let mut timeline = egg_mode::direct::received(&token)
-///                                     .with_page_size(10);
-///
-/// for dm in timeline.start().await.unwrap().iter() {
-///     println!("<@{}> {}", dm.sender_screen_name, dm.text);
-/// }
-/// # }
-/// ```
-///
-/// If you need to load the next set of messages, call `older`, which will automatically update the
-/// IDs it tracks:
-///
-/// ```rust,no_run
-/// # use egg_mode::Token;
-/// # #[tokio::main]
-/// # async fn main() {
-/// # let token: Token = unimplemented!();
-/// # let mut timeline = egg_mode::direct::received(&token);
-/// # timeline.start().await.unwrap();
-/// for dm in timeline.older(None).await.unwrap().iter() {
-///     println!("<@{}> {}", dm.sender_screen_name, dm.text);
-/// }
-/// # }
-/// ```
-///
-/// ...and similarly for `newer`, which operates in a similar fashion.
-///
-/// If you want to start afresh and reload the newest set of DMs again, you can call `start` again,
-/// which will clear the tracked IDs before loading the newest set of messages. However, if you've
-/// been storing these messages as you go, and already know the newest ID you have on hand, you can
-/// load only those messages you need like this:
-///
-/// ```rust,no_run
-/// # use egg_mode::Token;
-/// # #[tokio::main]
-/// # async fn main() {
-/// # let token: Token = unimplemented!();
-/// let mut timeline = egg_mode::direct::received(&token)
-///                                     .with_page_size(10);
-///
-/// timeline.start().await.unwrap();
-///
-/// //keep the max_id for later
-/// let reload_id = timeline.max_id.unwrap();
-///
-/// //simulate scrolling down a little bit
-/// timeline.older(None).await.unwrap();
-/// timeline.older(None).await.unwrap();
-///
-/// //reload the timeline with only what's new
-/// timeline.reset();
-/// timeline.older(Some(reload_id)).await.unwrap();
-/// # }
-/// ```
-///
-/// Here, the argument to `older` means "older than what I just returned, but newer than the given
-/// ID". Since we cleared the tracked IDs with `reset`, that turns into "the newest DMs available
-/// that were sent after the given ID". The earlier invocations of `older` with `None` do not place
-/// a bound on the DMs it loads. `newer` operates in a similar fashion with its argument, saying
-/// "newer than what I just returned, but not newer than this given ID". When called like this,
-/// it's possible for these methods to return nothing, which will also clear the `Timeline`'s
-/// tracked IDs.
-///
-/// If you want to manually pull messages between certain IDs, the baseline `call` function can do
-/// that for you. Keep in mind, though, that `call` doesn't update the `min_id` or `max_id` fields,
-/// so you'll have to set those yourself if you want to follow up with `older` or `newer`.
-pub struct Timeline {
-    ///The URL to request DMs from.
-    link: &'static str,
-    ///The token used to authenticate requests with.
-    token: auth::Token,
-    ///Optional set of params to include prior to adding timeline navigation parameters.
-    params_base: Option<ParamList>,
-    ///The maximum number of messages to return in a single call. Twitter doesn't guarantee
-    ///returning exactly this number, as suspended or deleted content is removed after retrieving
-    ///the initial collection of messages.
-    pub count: i32,
-    ///The largest/most recent DM ID returned in the last call to `start`, `older`, or `newer`.
-    pub max_id: Option<u64>,
-    ///The smallest/oldest DM ID returned in the last call to `start`, `older`, or `newer`.
-    pub min_id: Option<u64>,
-}
+///// Helper struct to navigate collections of direct messages by requesting DMs older or newer than
+///// certain IDs.
+/////
+///// Using a Timeline to navigate collections of DMs allows you to efficiently cursor through a
+///// collection and only load in the messages you need.
+/////
+///// To begin, call a method that returns a `Timeline`, optionally set the page size, and call
+///// `start` to load the first page of results:
+/////
+///// ```rust,no_run
+///// # use egg_mode::Token;
+///// # #[tokio::main]
+///// # async fn main() {
+///// # let token: Token = unimplemented!();
+///// let mut timeline = egg_mode::direct::received(&token)
+/////                                     .with_page_size(10);
+/////
+///// for dm in timeline.start().await.unwrap().iter() {
+/////     println!("<@{}> {}", dm.sender_screen_name, dm.text);
+///// }
+///// # }
+///// ```
+/////
+///// If you need to load the next set of messages, call `older`, which will automatically update the
+///// IDs it tracks:
+/////
+///// ```rust,no_run
+///// # use egg_mode::Token;
+///// # #[tokio::main]
+///// # async fn main() {
+///// # let token: Token = unimplemented!();
+///// # let mut timeline = egg_mode::direct::received(&token);
+///// # timeline.start().await.unwrap();
+///// for dm in timeline.older(None).await.unwrap().iter() {
+/////     println!("<@{}> {}", dm.sender_screen_name, dm.text);
+///// }
+///// # }
+///// ```
+/////
+///// ...and similarly for `newer`, which operates in a similar fashion.
+/////
+///// If you want to start afresh and reload the newest set of DMs again, you can call `start` again,
+///// which will clear the tracked IDs before loading the newest set of messages. However, if you've
+///// been storing these messages as you go, and already know the newest ID you have on hand, you can
+///// load only those messages you need like this:
+/////
+///// ```rust,no_run
+///// # use egg_mode::Token;
+///// # #[tokio::main]
+///// # async fn main() {
+///// # let token: Token = unimplemented!();
+///// let mut timeline = egg_mode::direct::received(&token)
+/////                                     .with_page_size(10);
+/////
+///// timeline.start().await.unwrap();
+/////
+///// //keep the max_id for later
+///// let reload_id = timeline.max_id.unwrap();
+/////
+///// //simulate scrolling down a little bit
+///// timeline.older(None).await.unwrap();
+///// timeline.older(None).await.unwrap();
+/////
+///// //reload the timeline with only what's new
+///// timeline.reset();
+///// timeline.older(Some(reload_id)).await.unwrap();
+///// # }
+///// ```
+/////
+///// Here, the argument to `older` means "older than what I just returned, but newer than the given
+///// ID". Since we cleared the tracked IDs with `reset`, that turns into "the newest DMs available
+///// that were sent after the given ID". The earlier invocations of `older` with `None` do not place
+///// a bound on the DMs it loads. `newer` operates in a similar fashion with its argument, saying
+///// "newer than what I just returned, but not newer than this given ID". When called like this,
+///// it's possible for these methods to return nothing, which will also clear the `Timeline`'s
+///// tracked IDs.
+/////
+///// If you want to manually pull messages between certain IDs, the baseline `call` function can do
+///// that for you. Keep in mind, though, that `call` doesn't update the `min_id` or `max_id` fields,
+///// so you'll have to set those yourself if you want to follow up with `older` or `newer`.
+//pub struct Timeline {
+//    ///The URL to request DMs from.
+//    link: &'static str,
+//    ///The token used to authenticate requests with.
+//    token: auth::Token,
+//    ///Optional set of params to include prior to adding timeline navigation parameters.
+//    params_base: Option<ParamList>,
+//    ///The maximum number of messages to return in a single call. Twitter doesn't guarantee
+//    ///returning exactly this number, as suspended or deleted content is removed after retrieving
+//    ///the initial collection of messages.
+//    pub count: i32,
+//    ///The largest/most recent DM ID returned in the last call to `start`, `older`, or `newer`.
+//    pub max_id: Option<u64>,
+//    ///The smallest/oldest DM ID returned in the last call to `start`, `older`, or `newer`.
+//    pub min_id: Option<u64>,
+//}
 
-impl Timeline {
-    ///Clear the saved IDs on this timeline.
-    pub fn reset(&mut self) {
-        self.max_id = None;
-        self.min_id = None;
-    }
+//impl Timeline {
+//    ///Clear the saved IDs on this timeline.
+//    pub fn reset(&mut self) {
+//        self.max_id = None;
+//        self.min_id = None;
+//    }
 
-    ///Clear the saved IDs on this timeline, and return the most recent set of messages.
-    pub fn start<'s>(
-        &'s mut self,
-    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
-        self.reset();
-        self.older(None)
-    }
+//    ///Clear the saved IDs on this timeline, and return the most recent set of messages.
+//    pub fn start<'s>(
+//        &'s mut self,
+//    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
+//        self.reset();
+//        self.older(None)
+//    }
 
-    ///Return the set of DMs older than the last set pulled, optionally placing a minimum DM ID to
-    ///bound with.
-    pub fn older<'s>(
-        &'s mut self,
-        since_id: Option<u64>,
-    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
-        let req = self.request(since_id, self.min_id.map(|id| id - 1));
-        let loader = request_with_json_response(req);
-        loader.map(
-            move |resp: Result<Response<Vec<DirectMessage>>, error::Error>| {
-                let resp = resp?;
-                self.map_ids(&resp.response);
-                Ok(resp)
-            },
-        )
-    }
+//    ///Return the set of DMs older than the last set pulled, optionally placing a minimum DM ID to
+//    ///bound with.
+//    pub fn older<'s>(
+//        &'s mut self,
+//        since_id: Option<u64>,
+//    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
+//        let req = self.request(since_id, self.min_id.map(|id| id - 1));
+//        let loader = request_with_json_response(req);
+//        loader.map(
+//            move |resp: Result<Response<Vec<DirectMessage>>, error::Error>| {
+//                let resp = resp?;
+//                self.map_ids(&resp.response);
+//                Ok(resp)
+//            },
+//        )
+//    }
 
-    ///Return the set of DMs newer than the last set pulled, optionally placing a maximum DM ID to
-    ///bound with.
-    pub fn newer<'s>(
-        &'s mut self,
-        max_id: Option<u64>,
-    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
-        let req = self.request(self.max_id, max_id);
-        let loader = request_with_json_response(req);
-        loader.map(
-            move |resp: Result<Response<Vec<DirectMessage>>, error::Error>| {
-                let resp = resp?;
-                self.map_ids(&resp.response);
-                Ok(resp)
-            },
-        )
-    }
+//    ///Return the set of DMs newer than the last set pulled, optionally placing a maximum DM ID to
+//    ///bound with.
+//    pub fn newer<'s>(
+//        &'s mut self,
+//        max_id: Option<u64>,
+//    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> + 's {
+//        let req = self.request(self.max_id, max_id);
+//        let loader = request_with_json_response(req);
+//        loader.map(
+//            move |resp: Result<Response<Vec<DirectMessage>>, error::Error>| {
+//                let resp = resp?;
+//                self.map_ids(&resp.response);
+//                Ok(resp)
+//            },
+//        )
+//    }
 
-    ///Return the set of DMs between the IDs given.
-    ///
-    ///Note that the range is not fully inclusive; the message ID given by `since_id` will not be
-    ///returned, but the message with `max_id` will be returned.
-    ///
-    ///If the range of DMs given by the IDs would return more than `self.count`, the newest set
-    ///of messages will be returned.
-    pub fn call(
-        &self,
-        since_id: Option<u64>,
-        max_id: Option<u64>,
-    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> {
-        request_with_json_response(self.request(since_id, max_id))
-    }
+//    ///Return the set of DMs between the IDs given.
+//    ///
+//    ///Note that the range is not fully inclusive; the message ID given by `since_id` will not be
+//    ///returned, but the message with `max_id` will be returned.
+//    ///
+//    ///If the range of DMs given by the IDs would return more than `self.count`, the newest set
+//    ///of messages will be returned.
+//    pub fn call(
+//        &self,
+//        since_id: Option<u64>,
+//        max_id: Option<u64>,
+//    ) -> impl Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>> {
+//        request_with_json_response(self.request(since_id, max_id))
+//    }
 
-    ///Helper builder function to set the page size.
-    pub fn with_page_size(self, page_size: i32) -> Self {
-        Timeline {
-            count: page_size,
-            ..self
-        }
-    }
+//    ///Helper builder function to set the page size.
+//    pub fn with_page_size(self, page_size: i32) -> Self {
+//        Timeline {
+//            count: page_size,
+//            ..self
+//        }
+//    }
 
-    ///Helper function to construct a `Request` from the current state.
-    fn request(&self, since_id: Option<u64>, max_id: Option<u64>) -> Request<Body> {
-        let params = ParamList::from(self.params_base.as_ref().cloned().unwrap_or_default())
-            .add_param("count", self.count.to_string())
-            .add_opt_param("since_id", since_id.map(|v| v.to_string()))
-            .add_opt_param("max_id", max_id.map(|v| v.to_string()));
+//    ///Helper function to construct a `Request` from the current state.
+//    fn request(&self, since_id: Option<u64>, max_id: Option<u64>) -> Request<Body> {
+//        let params = ParamList::from(self.params_base.as_ref().cloned().unwrap_or_default())
+//            .add_param("count", self.count.to_string())
+//            .add_opt_param("since_id", since_id.map(|v| v.to_string()))
+//            .add_opt_param("max_id", max_id.map(|v| v.to_string()));
 
-        get(self.link, &self.token, Some(&params))
-    }
+//        get(self.link, &self.token, Some(&params))
+//    }
 
-    ///With the returned slice of DMs, set the min_id and max_id on self.
-    fn map_ids(&mut self, resp: &[DirectMessage]) {
-        self.max_id = resp.first().map(|status| status.id);
-        self.min_id = resp.last().map(|status| status.id);
-    }
+//    ///With the returned slice of DMs, set the min_id and max_id on self.
+//    fn map_ids(&mut self, resp: &[DirectMessage]) {
+//        self.max_id = resp.first().map(|status| status.id);
+//        self.min_id = resp.last().map(|status| status.id);
+//    }
 
-    ///Create an instance of `Timeline` with the given link and tokens.
-    pub(crate) fn new(link: &'static str, params_base: Option<ParamList>, token: &auth::Token) -> Self {
-        Timeline {
-            link: link,
-            token: token.clone(),
-            params_base: params_base,
-            count: 20,
-            max_id: None,
-            min_id: None,
-        }
-    }
-}
+//    ///Create an instance of `Timeline` with the given link and tokens.
+//    pub(crate) fn new(link: &'static str, params_base: Option<ParamList>, token: &auth::Token) -> Self {
+//        Timeline {
+//            link: link,
+//            token: token.clone(),
+//            params_base: params_base,
+//            count: 20,
+//            max_id: None,
+//            min_id: None,
+//        }
+//    }
+//}
 
-///Wrapper around a collection of direct messages, sorted by their recipient.
-///
-///The mapping exposed here is from a User ID to a listing of direct messages between the
-///authenticated user and that user. For more information, see the docs for [`ConversationTimeline`].
-///
-///[`ConversationTimeline`]: struct.ConversationTimeline.html
-pub type DMConversations = HashMap<u64, Vec<DirectMessage>>;
+/////Wrapper around a collection of direct messages, sorted by their recipient.
+/////
+/////The mapping exposed here is from a User ID to a listing of direct messages between the
+/////authenticated user and that user. For more information, see the docs for [`ConversationTimeline`].
+/////
+/////[`ConversationTimeline`]: struct.ConversationTimeline.html
+//pub type DMConversations = HashMap<u64, Vec<DirectMessage>>;
 
-///Load the given set of conversations into this set.
-fn merge(this: &mut DMConversations, conversations: DMConversations) {
-    for (id, convo) in conversations {
-        let messages = this.entry(id).or_insert(Vec::new());
-        let cap = convo.len() + messages.len();
-        let old_convo = mem::replace(messages, Vec::with_capacity(cap));
+/////Load the given set of conversations into this set.
+//fn merge(this: &mut DMConversations, conversations: DMConversations) {
+//    for (id, convo) in conversations {
+//        let messages = this.entry(id).or_insert(Vec::new());
+//        let cap = convo.len() + messages.len();
+//        let old_convo = mem::replace(messages, Vec::with_capacity(cap));
 
-        //ASSUMPTION: these conversation threads are disjoint
-        if old_convo.first().map(|m| m.id).unwrap_or(0) > convo.first().map(|m| m.id).unwrap_or(0) {
-            messages.extend(old_convo);
-            messages.extend(convo);
-        } else {
-            messages.extend(convo);
-            messages.extend(old_convo);
-        }
-    }
-}
+//        //ASSUMPTION: these conversation threads are disjoint
+//        if old_convo.first().map(|m| m.id).unwrap_or(0) > convo.first().map(|m| m.id).unwrap_or(0) {
+//            messages.extend(old_convo);
+//            messages.extend(convo);
+//        } else {
+//            messages.extend(convo);
+//            messages.extend(old_convo);
+//        }
+//    }
+//}
 
-/// Helper struct to load both sent and received direct messages, pre-sorting them into
-/// conversations by their recipient.
-///
-/// This timeline loader is meant to get around a limitation of the direct message API endpoints:
-/// Twitter only gives endpoints to load all the messages *sent* by the authenticated user, or all
-/// the messages *received* by the authenticated user. However, the common user interface for DMs
-/// is to separate them by the other account in the conversation. This loader is a higher-level
-/// wrapper over the direct `sent` and `received` calls to achieve this interface without library
-/// users having to implement it themselves.
-///
-/// Much like [`Timeline`], simply receiving a `ConversationTimeline` from `conversations` does not
-/// load any messages on its own. This is to allow setting the page size before loading the first
-/// batch of messages.
-///
-/// [`Timeline`]: struct.Timeline.html
-///
-/// `ConversationTimeline` keeps a cache of all the messages its loaded, and updates this during
-/// calls to Twitter. Any calls on this timeline that generate a `ConversationFuture` will take
-/// ownership of the `ConversationTimeline` so that it can update this cache. The Future will
-/// return the `ConversationTimeline` on success. To view the current cache, use the
-/// `conversations` field.
-///
-/// There are two methods to load messages, and they operate by extending the cache by loading
-/// messages either older or newer than the extent of the cache.
-///
-/// **NOTE**: Twitter has different API limitations for sent versus received messages. You can only
-/// load the most recent 200 *received* messages through the public API, but you can load up to 800
-/// *sent* messages. This can create some strange user-interface if a user has some old
-/// conversations, as they can only see their own side of the conversation this way. If you'd like
-/// to load as many messages as possible, both API endpoints have a per-call limit of 200. Setting
-/// the page size to 200 prior to loading messages allows you to use one function call to load a
-/// fairly-complete view of the user's conversations.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use egg_mode::Token;
-/// # #[tokio::main]
-/// # async fn main() {
-/// # let token: Token = unimplemented!();
-/// let mut conversations = egg_mode::direct::conversations(&token);
-///
-/// // newest() and oldest() consume the Timeline and give it back on success, so assign it back
-/// // when it's done
-/// conversations = conversations.newest().await.unwrap();
-///
-/// for (id, convo) in &conversations.conversations {
-///     let user = egg_mode::user::show(*id, &token).await.unwrap();
-///     println!("Conversation with @{}", user.screen_name);
-///     for msg in convo {
-///         println!("<@{}> {}", msg.sender_screen_name, msg.text);
-///     }
-/// }
-/// # }
-/// ```
-pub struct ConversationTimeline {
-    sent: Timeline,
-    received: Timeline,
-    ///The message ID of the most recent sent message in the current conversation set.
-    pub last_sent: Option<u64>,
-    ///The message ID of the most recent received message in the current conversation set.
-    pub last_received: Option<u64>,
-    ///The message ID of the oldest sent message in the current conversation set.
-    pub first_sent: Option<u64>,
-    ///The message ID of the oldest received message in the current conversation set.
-    pub first_received: Option<u64>,
-    ///The number of messages loaded per API call.
-    pub count: u32,
-    ///The conversation threads that have been loaded so far.
-    pub conversations: DMConversations,
-}
+///// Helper struct to load both sent and received direct messages, pre-sorting them into
+///// conversations by their recipient.
+/////
+///// This timeline loader is meant to get around a limitation of the direct message API endpoints:
+///// Twitter only gives endpoints to load all the messages *sent* by the authenticated user, or all
+///// the messages *received* by the authenticated user. However, the common user interface for DMs
+///// is to separate them by the other account in the conversation. This loader is a higher-level
+///// wrapper over the direct `sent` and `received` calls to achieve this interface without library
+///// users having to implement it themselves.
+/////
+///// Much like [`Timeline`], simply receiving a `ConversationTimeline` from `conversations` does not
+///// load any messages on its own. This is to allow setting the page size before loading the first
+///// batch of messages.
+/////
+///// [`Timeline`]: struct.Timeline.html
+/////
+///// `ConversationTimeline` keeps a cache of all the messages its loaded, and updates this during
+///// calls to Twitter. Any calls on this timeline that generate a `ConversationFuture` will take
+///// ownership of the `ConversationTimeline` so that it can update this cache. The Future will
+///// return the `ConversationTimeline` on success. To view the current cache, use the
+///// `conversations` field.
+/////
+///// There are two methods to load messages, and they operate by extending the cache by loading
+///// messages either older or newer than the extent of the cache.
+/////
+///// **NOTE**: Twitter has different API limitations for sent versus received messages. You can only
+///// load the most recent 200 *received* messages through the public API, but you can load up to 800
+///// *sent* messages. This can create some strange user-interface if a user has some old
+///// conversations, as they can only see their own side of the conversation this way. If you'd like
+///// to load as many messages as possible, both API endpoints have a per-call limit of 200. Setting
+///// the page size to 200 prior to loading messages allows you to use one function call to load a
+///// fairly-complete view of the user's conversations.
+/////
+///// # Example
+/////
+///// ```rust,no_run
+///// # use egg_mode::Token;
+///// # #[tokio::main]
+///// # async fn main() {
+///// # let token: Token = unimplemented!();
+///// let mut conversations = egg_mode::direct::conversations(&token);
+/////
+///// // newest() and oldest() consume the Timeline and give it back on success, so assign it back
+///// // when it's done
+///// conversations = conversations.newest().await.unwrap();
+/////
+///// for (id, convo) in &conversations.conversations {
+/////     let user = egg_mode::user::show(*id, &token).await.unwrap();
+/////     println!("Conversation with @{}", user.screen_name);
+/////     for msg in convo {
+/////         println!("<@{}> {}", msg.sender_screen_name, msg.text);
+/////     }
+///// }
+///// # }
+///// ```
+//pub struct ConversationTimeline {
+//    sent: Timeline,
+//    received: Timeline,
+//    ///The message ID of the most recent sent message in the current conversation set.
+//    pub last_sent: Option<u64>,
+//    ///The message ID of the most recent received message in the current conversation set.
+//    pub last_received: Option<u64>,
+//    ///The message ID of the oldest sent message in the current conversation set.
+//    pub first_sent: Option<u64>,
+//    ///The message ID of the oldest received message in the current conversation set.
+//    pub first_received: Option<u64>,
+//    ///The number of messages loaded per API call.
+//    pub count: u32,
+//    ///The conversation threads that have been loaded so far.
+//    pub conversations: DMConversations,
+//}
 
-impl ConversationTimeline {
-    fn new(token: &auth::Token) -> ConversationTimeline {
-        ConversationTimeline {
-            sent: sent(token),
-            received: received(token),
-            last_sent: None,
-            last_received: None,
-            first_sent: None,
-            first_received: None,
-            count: 20,
-            conversations: HashMap::new(),
-        }
-    }
+//impl ConversationTimeline {
+//    fn new(token: &auth::Token) -> ConversationTimeline {
+//        ConversationTimeline {
+//            sent: sent(token),
+//            received: received(token),
+//            last_sent: None,
+//            last_received: None,
+//            first_sent: None,
+//            first_received: None,
+//            count: 20,
+//            conversations: HashMap::new(),
+//        }
+//    }
 
-    fn merge(&mut self, sent: Vec<DirectMessage>, received: Vec<DirectMessage>) {
-        self.last_sent = max_opt(self.last_sent, sent.first().map(|m| m.id));
-        self.last_received = max_opt(self.last_received, received.first().map(|m| m.id));
-        self.first_sent = min_opt(self.first_sent, sent.last().map(|m| m.id));
-        self.first_received = min_opt(self.first_received, received.last().map(|m| m.id));
+//    fn merge(&mut self, sent: Vec<DirectMessage>, received: Vec<DirectMessage>) {
+//        self.last_sent = max_opt(self.last_sent, sent.first().map(|m| m.id));
+//        self.last_received = max_opt(self.last_received, received.first().map(|m| m.id));
+//        self.first_sent = min_opt(self.first_sent, sent.last().map(|m| m.id));
+//        self.first_received = min_opt(self.first_received, received.last().map(|m| m.id));
 
-        let sender = sent.first().map(|m| m.sender_id);
-        let receiver = received.first().map(|m| m.recipient_id);
+//        let sender = sent.first().map(|m| m.sender_id);
+//        let receiver = received.first().map(|m| m.recipient_id);
 
-        if let Some(me_id) = sender.or(receiver) {
-            let mut new_convo = HashMap::new();
+//        if let Some(me_id) = sender.or(receiver) {
+//            let mut new_convo = HashMap::new();
 
-            for msg in merge_by(sent, received, |left, right| left.id > right.id) {
-                let recipient = if msg.sender_id == me_id {
-                    msg.recipient_id
-                } else {
-                    msg.sender_id
-                };
+//            for msg in merge_by(sent, received, |left, right| left.id > right.id) {
+//                let recipient = if msg.sender_id == me_id {
+//                    msg.recipient_id
+//                } else {
+//                    msg.sender_id
+//                };
 
-                let thread = new_convo.entry(recipient).or_insert(Vec::new());
-                thread.push(msg);
-            }
+//                let thread = new_convo.entry(recipient).or_insert(Vec::new());
+//                thread.push(msg);
+//            }
 
-            merge(&mut self.conversations, new_convo);
-        }
-    }
+//            merge(&mut self.conversations, new_convo);
+//        }
+//    }
 
-    ///Builder function to set the number of messages pulled in a single request.
-    pub fn with_page_size(self, page_size: u32) -> ConversationTimeline {
-        ConversationTimeline {
-            count: page_size,
-            ..self
-        }
-    }
+//    ///Builder function to set the number of messages pulled in a single request.
+//    pub fn with_page_size(self, page_size: u32) -> ConversationTimeline {
+//        ConversationTimeline {
+//            count: page_size,
+//            ..self
+//        }
+//    }
 
-    ///Load messages newer than the currently-loaded set, or the newset set if no messages have
-    ///been loaded yet. The complete conversation set can be viewed from the `ConversationTimeline`
-    ///after it is finished loading.
-    pub async fn newest(self) -> Result<ConversationTimeline, error::Error> {
-        let sent = self.sent.call(self.last_sent, None);
-        let received = self.received.call(self.last_received, None);
+//    ///Load messages newer than the currently-loaded set, or the newset set if no messages have
+//    ///been loaded yet. The complete conversation set can be viewed from the `ConversationTimeline`
+//    ///after it is finished loading.
+//    pub async fn newest(self) -> Result<ConversationTimeline, error::Error> {
+//        let sent = self.sent.call(self.last_sent, None);
+//        let received = self.received.call(self.last_received, None);
 
-        self.make_future(sent, received).await
-    }
+//        self.make_future(sent, received).await
+//    }
 
-    ///Load messages older than the currently-loaded set, or the newest set if no messages have
-    ///been loaded. The complete conversation set can be viewed from the `ConversationTimeline`
-    ///after it is finished loading.
-    pub fn next(self) -> impl Future<Output = Result<ConversationTimeline, error::Error>> {
-        let sent = self.sent.call(None, self.first_sent);
-        let received = self.received.call(None, self.first_received);
+//    ///Load messages older than the currently-loaded set, or the newest set if no messages have
+//    ///been loaded. The complete conversation set can be viewed from the `ConversationTimeline`
+//    ///after it is finished loading.
+//    pub fn next(self) -> impl Future<Output = Result<ConversationTimeline, error::Error>> {
+//        let sent = self.sent.call(None, self.first_sent);
+//        let received = self.received.call(None, self.first_received);
 
-        self.make_future(sent, received)
-    }
+//        self.make_future(sent, received)
+//    }
 
-    async fn make_future<S, R>(
-        mut self,
-        sent: S,
-        received: R,
-    ) -> Result<ConversationTimeline, error::Error>
-    where
-        S: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
-        R: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
-    {
-        let (sent, received) = futures::future::join(sent, received).await;
-        let sent = sent?;
-        let received = received?;
-        self.merge(sent.response, received.response);
-        Ok(self)
-    }
-}
+//    async fn make_future<S, R>(
+//        mut self,
+//        sent: S,
+//        received: R,
+//    ) -> Result<ConversationTimeline, error::Error>
+//    where
+//        S: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
+//        R: Future<Output = Result<Response<Vec<DirectMessage>>, error::Error>>,
+//    {
+//        let (sent, received) = futures::future::join(sent, received).await;
+//        let sent = sent?;
+//        let received = received?;
+//        self.merge(sent.response, received.response);
+//        Ok(self)
+//    }
+//}

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -48,7 +48,7 @@ use crate::user::{self, UserID};
 use crate::tweet::TweetSource;
 
 mod fun;
-mod raw;
+pub(crate) mod raw;
 
 pub use self::fun::*;
 

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -300,7 +300,7 @@ impl Timeline {
                 let mut resp = resp?;
                 self.loaded = true;
                 self.next_cursor = resp.next_cursor.take();
-                Ok(Response::map(resp, |evs| evs.into()))
+                Ok(Response::into(resp))
             }
         )
     }
@@ -584,6 +584,6 @@ impl DraftMessage {
         });
         let req = post_json(links::direct::SEND, token, message);
         let resp: Response<raw::SingleEvent> = request_with_json_response(req).await?;
-        Ok(Response::map(resp, |ev| ev.into()))
+        Ok(Response::into(resp))
     }
 }

--- a/src/direct/mod.rs
+++ b/src/direct/mod.rs
@@ -13,16 +13,15 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::future::Future;
-use std::mem;
 
 use chrono;
 use futures::FutureExt;
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 use hyper::{Body, Request};
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 
 use crate::common::*;
-use crate::{auth, entities, error, user};
+use crate::{auth, entities, error};
 use crate::tweet::TweetSource;
 
 mod fun;
@@ -87,30 +86,6 @@ impl TryFrom<raw::EventCursor> for Vec<DirectMessage> {
         Ok(ret)
     }
 }
-
-// impl<'de> Deserialize<'de> for DirectMessage {
-//     fn deserialize<D>(deser: D) -> Result<DirectMessage, D::Error>
-//     where
-//         D: Deserializer<'de>,
-//     {
-//         let mut raw = raw::RawDirectMessage::deserialize(deser)?;
-
-//         raw.translate_indices();
-
-//         Ok(DirectMessage {
-//             id: raw.id,
-//             created_at: raw.created_at,
-//             text: raw.text,
-//             entities: raw.entities,
-//             attachment: raw.attachment,
-//             ctas: raw.ctas,
-//             sender_id: raw.sender_id,
-//             recipient_id: raw.recipient_id,
-//             quick_replies: raw.quick_replies,
-//             quick_reply_response: raw.quick_reply_response,
-//         })
-//     }
-// }
 
 /// Container for URL, hashtag, and mention information associated with a direct message.
 ///

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -88,8 +88,8 @@ impl From<DMEvent> for RawDirectMessage {
     fn from(ev: DMEvent) -> RawDirectMessage {
         use chrono::TimeZone;
         RawDirectMessage {
-            id: ev.ev.id,
-            created_at: chrono::Utc.timestamp_millis(ev.ev.created_timestamp),
+            id: ev.id,
+            created_at: chrono::Utc.timestamp_millis(ev.created_timestamp),
             text: ev.message_create.message_data.text,
             entities: ev.message_create.message_data.entities,
             attachment: ev.message_create.message_data.attachment.map(|a| a.media),
@@ -133,17 +133,11 @@ impl EventType {
 }
 
 #[derive(Deserialize)]
-struct EventCommon {
+pub struct DMEvent {
     #[serde(deserialize_with = "deser_from_string")]
     id: u64,
     #[serde(deserialize_with = "deser_from_string")]
     created_timestamp: i64,
-}
-
-#[derive(Deserialize)]
-pub struct DMEvent {
-    #[serde(flatten)]
-    ev: EventCommon,
     message_create: MessageCreateEvent,
 }
 

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -10,7 +10,6 @@ use chrono;
 use serde::Deserialize;
 
 use crate::entities::MediaEntity;
-use crate::error;
 use crate::tweet::TweetSource;
 
 use super::{DMEntities, Cta, QuickReply, DirectMessage};
@@ -101,14 +100,12 @@ impl RawDirectMessage {
     /// information is discarded.
     ///
     /// This conversion also calls `translate_indices` before constructing the `DirectMessage`.
-    // TODO: this doesn't actually need to return a Result any more
-    pub fn into_dm(mut self, apps: &HashMap<String, TweetSource>)
-        -> error::Result<DirectMessage>
+    pub fn into_dm(mut self, apps: &HashMap<String, TweetSource>) -> DirectMessage
     {
         self.translate_indices();
         let source_app = self.source_app_id.and_then(|id| apps.get(&id).cloned());
 
-        Ok(DirectMessage {
+        DirectMessage {
             id: self.id,
             created_at: self.created_at,
             text: self.text,
@@ -120,7 +117,7 @@ impl RawDirectMessage {
             recipient_id: self.recipient_id,
             quick_replies: self.quick_replies,
             quick_reply_response: self.quick_reply_response,
-        })
+        }
     }
 
     // TODO: provide a conversion that drops source-app information?

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -106,12 +106,14 @@ impl From<DMEvent> for RawDirectMessage {
 #[derive(Deserialize)]
 pub struct SingleEvent {
     pub event: EventType,
+    #[serde(default)]
     pub apps: HashMap<String, TweetSource>,
 }
 
 #[derive(Deserialize)]
 pub struct EventCursor {
     pub events: Vec<EventType>,
+    #[serde(default)]
     pub apps: HashMap<String, TweetSource>,
     pub next_cursor: Option<String>,
 }

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -3,34 +3,84 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::common::*;
-use crate::user;
 
 use chrono;
 use serde::Deserialize;
 
+use crate::entities::MediaEntity;
+
 use super::DMEntities;
 
 #[derive(Debug, Deserialize)]
+#[serde(from = "DMEvent")]
 pub struct RawDirectMessage {
     ///Numeric ID for this DM.
     pub id: u64,
     ///UTC timestamp from when this DM was created.
-    #[serde(deserialize_with = "deserialize_datetime")]
     pub created_at: chrono::DateTime<chrono::Utc>,
     ///The text of the DM.
     pub text: String,
     ///Link, hashtag, and user mention information parsed out of the DM.
     pub entities: DMEntities,
-    ///The screen name of the user who sent the DM.
-    pub sender_screen_name: String,
+    ///Media attached to the DM, if present.
+    pub attachment: Option<MediaEntity>,
     ///The ID of the user who sent the DM.
     pub sender_id: u64,
-    ///Full information of the user who sent the DM.
-    pub sender: Box<user::TwitterUser>,
-    ///The screen name of the user who received the DM.
-    pub recipient_screen_name: String,
     ///The ID of the user who received the DM.
     pub recipient_id: u64,
-    ///Full information for the user who received the DM.
-    pub recipient: Box<user::TwitterUser>,
+}
+
+// DMs received from twitter are structured as events in their activity API, which means they have
+// a lot of deep nesting for how they are structured. The types and From impl below convert that
+// into a flat object ready for processing/export by egg-mode.
+
+impl From<DMEvent> for RawDirectMessage {
+    fn from(ev: DMEvent) -> RawDirectMessage {
+        use chrono::TimeZone;
+        RawDirectMessage {
+            id: ev.id,
+            created_at: chrono::Utc.timestamp_millis(ev.created_at),
+            text: ev.message_create.message_data.text,
+            entities: ev.message_create.message_data.entities,
+            attachment: ev.message_create.message_data.attachment.map(|a| a.media),
+            sender_id: ev.message_create.sender_id,
+            recipient_id: ev.message_create.target.recipient_id,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct DMEvent {
+    #[serde(deserialize_with = "deser_from_string")]
+    id: u64,
+    #[serde(deserialize_with = "deser_from_string")]
+    #[serde(rename = "created_timestamp")]
+    created_at: i64,
+    message_create: MessageCreateEvent,
+}
+
+#[derive(Deserialize)]
+struct MessageCreateEvent {
+    message_data: MessageData,
+    #[serde(deserialize_with = "deser_from_string")]
+    sender_id: u64,
+    target: MessageTarget,
+}
+
+#[derive(Deserialize)]
+struct MessageData {
+    attachment: Option<MessageAttachment>,
+    entities: DMEntities,
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct MessageAttachment {
+    media: MediaEntity,
+}
+
+#[derive(Deserialize)]
+struct MessageTarget {
+    #[serde(deserialize_with = "deser_from_string")]
+    recipient_id: u64,
 }

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -176,94 +176,98 @@ pub struct EventCursor {
 #[serde(rename_all="snake_case")]
 pub enum EventType {
     /// A `message_create` event, representing a direct message.
-    MessageCreate(DMEvent),
+    ///
+    /// The `message_create` event structure is flattened into a `RawDirectMessage` when
+    /// deserializing. It should be combined with the `apps` map in a `SingleEvent` or
+    /// `EventCursor` when converting into a `DirectMessage`.
+    MessageCreate(RawDirectMessage),
 }
 
 impl EventType {
-    /// Returns the inner `DMEvent` structure from the `message_create` event.
-    pub fn as_message_create(self) -> DMEvent {
-        let EventType::MessageCreate(ev) = self;
-        ev
+    /// Returns the inner `RawDirectMessage` structure from the `message_create` event.
+    pub fn as_raw_dm(self) -> RawDirectMessage {
+        let EventType::MessageCreate(dm) = self;
+        dm
     }
 }
 
 /// The root `message_create` event, representing a direct message.
 #[derive(Deserialize)]
-pub struct DMEvent {
+struct DMEvent {
     /// Numeric ID for the direct message.
     #[serde(deserialize_with = "deser_from_string")]
-    pub id: u64,
+    id: u64,
     /// UTC Unix timestamp for when the message was sent, encoded as the number of milliseconds
     /// since the Unix epoch.
     #[serde(deserialize_with = "deser_from_string")]
-    pub created_timestamp: i64,
+    created_timestamp: i64,
     /// Message data for this event.
-    pub message_create: MessageCreateEvent,
+    message_create: MessageCreateEvent,
 }
 
 /// The `message_create` data of a `DMEvent`, containing information about the direct message.
 #[derive(Deserialize)]
-pub struct MessageCreateEvent {
+struct MessageCreateEvent {
     /// The `message_data` portion of this event.
-    pub message_data: MessageData,
+    message_data: MessageData,
     #[serde(deserialize_with = "deser_from_string")]
     /// The numeric User ID of the sender.
-    pub sender_id: u64,
+    sender_id: u64,
     /// The string ID of the app used to send the message, if it was sent by the authenticated
     /// user.
-    pub source_app_id: Option<String>,
+    source_app_id: Option<String>,
     /// Information about the recipient of the message.
-    pub target: MessageTarget,
+    target: MessageTarget,
 }
 
 /// The `message_data` portion of a `DMEvent`, containing the bulk of information about a direct
 /// message.
 #[derive(Deserialize)]
-pub struct MessageData {
+struct MessageData {
     /// A list of "call to action" buttons, if present.
-    pub ctas: Option<Vec<Cta>>,
+    ctas: Option<Vec<Cta>>,
     /// Information about attached media, if present.
-    pub attachment: Option<MessageAttachment>,
+    attachment: Option<MessageAttachment>,
     /// Information about URL, hashtag, or user-mention entities used in the message.
-    pub entities: DMEntities,
+    entities: DMEntities,
     /// Information about Quick Reply options, if present.
-    pub quick_reply: Option<RawQuickReply>,
+    quick_reply: Option<RawQuickReply>,
     /// Information about a selected Quick Reply option, if the sender selected one.
-    pub quick_reply_response: Option<QuickReplyResponse>,
+    quick_reply_response: Option<QuickReplyResponse>,
     /// The message text.
-    pub text: String,
+    text: String,
 }
 
 /// Represents attached media information from within a `DMEvent`.
 #[derive(Deserialize)]
-pub struct MessageAttachment {
+struct MessageAttachment {
     /// Information about the attached media.
     ///
     /// Note that the indices used within the `MediaEntity` are received from Twitter using
     /// codepoint-based indexing. Using the indices from within this type directly without
     /// translating them may result in string-slicing errors or panics unless you translate the
     /// indices or use `char_indices` and `enumerate` yourself to ensure proper use of the indices.
-    pub media: MediaEntity,
+    media: MediaEntity,
 }
 
 /// Represents a list of Quick Reply options from within a `DMEvent`.
 #[derive(Deserialize)]
-pub struct RawQuickReply {
+struct RawQuickReply {
     /// The list of Quick Reply options sent with this message.
-    pub options: Vec<QuickReply>,
+    options: Vec<QuickReply>,
 }
 
 /// Represents the `metadata` from a selected Quick Reply from within a `DMEvent`.
 #[derive(Deserialize)]
-pub struct QuickReplyResponse {
+struct QuickReplyResponse {
     /// The `metadata` field for the Quick Reply option the sender selected.
-    pub metadata: String,
+    metadata: String,
 }
 
 /// Represents the message target from within a `DMEvent`.
 #[derive(Deserialize)]
-pub struct MessageTarget {
+struct MessageTarget {
     #[serde(deserialize_with = "deser_from_string")]
     /// The numeric user ID of the recipient of the message.
-    pub recipient_id: u64,
+    recipient_id: u64,
 }

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use crate::entities::MediaEntity;
 
-use super::DMEntities;
+use super::{DMEntities, Cta, QuickReply};
 
 #[derive(Debug, Deserialize)]
 #[serde(from = "DMEvent")]
@@ -24,6 +24,10 @@ pub struct RawDirectMessage {
     pub entities: DMEntities,
     ///Media attached to the DM, if present.
     pub attachment: Option<MediaEntity>,
+    ///A list of "call to action" buttons, if present.
+    pub ctas: Option<Vec<Cta>>,
+    pub quick_replies: Option<Vec<QuickReply>>,
+    pub quick_reply_response: Option<String>,
     ///The ID of the user who sent the DM.
     pub sender_id: u64,
     ///The ID of the user who received the DM.
@@ -43,8 +47,11 @@ impl From<DMEvent> for RawDirectMessage {
             text: ev.message_create.message_data.text,
             entities: ev.message_create.message_data.entities,
             attachment: ev.message_create.message_data.attachment.map(|a| a.media),
+            ctas: ev.message_create.message_data.ctas,
             sender_id: ev.message_create.sender_id,
             recipient_id: ev.message_create.target.recipient_id,
+            quick_replies: ev.message_create.message_data.quick_reply.map(|q| q.options),
+            quick_reply_response: ev.message_create.message_data.quick_reply_response.map(|q| q.metadata),
         }
     }
 }
@@ -69,14 +76,27 @@ struct MessageCreateEvent {
 
 #[derive(Deserialize)]
 struct MessageData {
+    ctas: Option<Vec<Cta>>,
     attachment: Option<MessageAttachment>,
     entities: DMEntities,
+    quick_reply: Option<RawQuickReply>,
+    quick_reply_response: Option<QuickReplyResponse>,
     text: String,
 }
 
 #[derive(Deserialize)]
 struct MessageAttachment {
     media: MediaEntity,
+}
+
+#[derive(Deserialize)]
+struct RawQuickReply {
+    options: Vec<QuickReply>,
+}
+
+#[derive(Deserialize)]
+struct QuickReplyResponse {
+    metadata: String,
 }
 
 #[derive(Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,4 +180,4 @@ pub mod tweet;
 pub mod user;
 
 pub use crate::auth::{Token, KeyPair};
-pub use crate::common::{Response, RateLimit};
+pub use crate::common::{Response, ResponseIter, RateLimit};

--- a/src/links.rs
+++ b/src/links.rs
@@ -111,7 +111,7 @@ pub mod direct {
     pub const SHOW: &'static str = "https://api.twitter.com/1.1/direct_messages/events/show.json";
     pub const LIST: &'static str = "https://api.twitter.com/1.1/direct_messages/events/list.json";
     pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/events/new.json";
-    pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/destroy.json";
+    pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/events/destroy.json";
 }
 
 pub mod service {

--- a/src/links.rs
+++ b/src/links.rs
@@ -110,7 +110,7 @@ pub mod place {
 pub mod direct {
     pub const SHOW: &'static str = "https://api.twitter.com/1.1/direct_messages/events/show.json";
     pub const LIST: &'static str = "https://api.twitter.com/1.1/direct_messages/events/list.json";
-    pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/new.json";
+    pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/events/new.json";
     pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/destroy.json";
 }
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -108,9 +108,8 @@ pub mod place {
 }
 
 pub mod direct {
-    pub const SHOW: &'static str = "https://api.twitter.com/1.1/direct_messages/show.json";
-    pub const RECEIVED: &'static str = "https://api.twitter.com/1.1/direct_messages.json";
-    pub const SENT: &'static str = "https://api.twitter.com/1.1/direct_messages/sent.json";
+    pub const SHOW: &'static str = "https://api.twitter.com/1.1/direct_messages/events/show.json";
+    pub const LIST: &'static str = "https://api.twitter.com/1.1/direct_messages/events/list.json";
     pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/new.json";
     pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/destroy.json";
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -113,6 +113,7 @@ pub mod direct {
     pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/events/new.json";
     pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/events/destroy.json";
     pub const MARK_READ: &'static str = "https://api.twitter.com/1.1/direct_messages/mark_read.json";
+    pub const INDICATE_TYPING: &'static str = "https://api.twitter.com/1.1/direct_messages/indicate_typing.json";
 }
 
 pub mod service {

--- a/src/links.rs
+++ b/src/links.rs
@@ -112,6 +112,7 @@ pub mod direct {
     pub const LIST: &'static str = "https://api.twitter.com/1.1/direct_messages/events/list.json";
     pub const SEND: &'static str = "https://api.twitter.com/1.1/direct_messages/events/new.json";
     pub const DELETE: &'static str = "https://api.twitter.com/1.1/direct_messages/events/destroy.json";
+    pub const MARK_READ: &'static str = "https://api.twitter.com/1.1/direct_messages/mark_read.json";
 }
 
 pub mod service {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -223,3 +223,12 @@ pub mod auth {
     #[doc(no_inline)]
     pub use hyper::Method;
 }
+
+/// Types that can be used for deserialization from the raw API.
+///
+/// In cases where the types in egg-mode do not directly implement `Deserialize`, types are
+/// available here that represent the data sent "across the wire", which can be converted into
+/// regular egg-mode types. See the individual module docs for details.
+pub mod types {
+    pub mod direct;
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -152,6 +152,7 @@ pub fn request_as_cursor_iter<T: cursor::Cursor + serde::de::DeserializeOwned>(
 pub use crate::common::get_response as response_future;
 pub use crate::common::raw_request as response_raw_bytes;
 pub use crate::common::request_with_json_response as response_json;
+pub use crate::common::request_with_empty_response as response_empty;
 
 /// Converts the given request into a `TwitterStream`.
 ///

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -82,6 +82,7 @@ pub use crate::common::ParamList;
 pub use crate::common::Headers;
 
 pub use crate::auth::raw::get as request_get;
+pub use crate::auth::raw::delete as request_delete;
 pub use crate::auth::raw::post as request_post;
 pub use crate::auth::raw::post_json as request_post_json;
 

--- a/src/raw/types/direct.rs
+++ b/src/raw/types/direct.rs
@@ -13,8 +13,8 @@
 //! All of the types in this module implement the `Deserialize` trait from serde, and can thus be
 //! converted from JSON returned from Twitter. The types `SingleEvent` and `EventCursor` match the
 //! data sent for the `show` and `list` endpoints, respectively, and can thus be deserialized
-//! directly from those responses. These types implement the `TryFrom` trait to be converted into a
-//! single `DirectMessage` or a `Vec<DirectMessage>`, respectively.
+//! directly from those responses. These types can then be used with implementations of the `From`
+//! trait to be converted into a single `DirectMessage` or a `Vec<DirectMessage>`, respectively.
 //!
 //! The `RawDirectMessage` type represents a minimally-processed version of the `message_create`
 //! event data sent by Twitter. It's contained within the `EventType` enum, which abstracts the

--- a/src/raw/types/direct.rs
+++ b/src/raw/types/direct.rs
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Raw types used by the Direct Message API.
+//!
+//! When loading direct messages from the Twitter API, they don't come across as singular
+//! structures that match the types that egg-mode exports. Instead, to match the Account Activity
+//! API that the DM functionality is a part of, they come across as "events" with a deeply-nested
+//! structure. If you would like to manually deserialize these events as part of using the raw
+//! egg-mode API, these types are exported here to allow this functionality.
+//!
+//! All of the types in this module implement the `Deserialize` trait from serde, and can thus be
+//! converted from JSON returned from Twitter. The types `SingleEvent` and `EventCursor` match the
+//! data sent for the `show` and `list` endpoints, respectively, and can thus be deserialized
+//! directly from those responses. These types implement the `TryFrom` trait to be converted into a
+//! single `DirectMessage` or a `Vec<DirectMessage>`, respectively. The other types in this module
+//! represent sub-structures of these event types, and are either contained within those types, or
+//! (in the case of `RawDirectMessage`) is converted from one of these other types during
+//! deserialization.
+
+pub use crate::direct::raw::*;

--- a/src/raw/types/direct.rs
+++ b/src/raw/types/direct.rs
@@ -14,9 +14,12 @@
 //! converted from JSON returned from Twitter. The types `SingleEvent` and `EventCursor` match the
 //! data sent for the `show` and `list` endpoints, respectively, and can thus be deserialized
 //! directly from those responses. These types implement the `TryFrom` trait to be converted into a
-//! single `DirectMessage` or a `Vec<DirectMessage>`, respectively. The other types in this module
-//! represent sub-structures of these event types, and are either contained within those types, or
-//! (in the case of `RawDirectMessage`) is converted from one of these other types during
-//! deserialization.
+//! single `DirectMessage` or a `Vec<DirectMessage>`, respectively.
+//!
+//! The `RawDirectMessage` type represents a minimally-processed version of the `message_create`
+//! event data sent by Twitter. It's contained within the `EventType` enum, which abstracts the
+//! fact that the event data structure allows for other types of events. As egg-mode only loads
+//! direct messages using these types, it only serves to ensure that the proper data is received by
+//! Twitter.
 
 pub use crate::direct::raw::*;


### PR DESCRIPTION
Back in 2018, Twitter introduced the new Account Activity API for Direct Messages, and deprecated the previous DM endpoints. egg-mode was never updated to use this new API, so when the old endpoints were shut off later that year, users couldn't use egg-mode to send and receive DMs any more.

This PR updates egg-mode's Direct Message functionality to use the new API. The functionality has been updated to reflect the new capabilities they added. Notably, it's no longer necessary to merge two different timelines to get a complete view of a user's Direct Messages - now there's a single `list` call that returns everything from the last 30 days. Also, now there are many things that can be added to a DM when you send it, including media, so the old `send` function has been converted into a `DraftMessage` type, a la the `DraftTweet` type for creating a tweet. The changelog has been updated with the full list of updates.

Closes #67 