### PR TITLE
impl Serialize for Tweet/TwitterUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - New function `Response::into`, to convert a `Response` using the `Into` trait
 - `Response` now implements `IntoIterator` if its contained type does
   - A new type `ResponseIter` has been introduced to contain this iterator
+- `Tweet` and `TwitterUser` now implement `Serialize`, and can be loaded either from Twitter's JSON
+  representation or from the serialized representation
+  - These types now have `twitter_deser_error` and `roundtrip_deser_error` functions to access error
+    messages from deserialization
 
 ## [0.15.0] - 2020-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@
   - A new type `ResponseIter` has been introduced to contain this iterator
 - `Tweet` and `TwitterUser` now implement `Serialize`, and can be loaded either from Twitter's JSON
   representation or from the serialized representation
-  - These types now have `twitter_deser_error` and `roundtrip_deser_error` functions to access error
-    messages from deserialization
+  - A new trait `raw::RoundTrip` has been introduced to enable users to capture deserialization
+    error messages
 
 ## [0.15.0] - 2020-06-11
 

--- a/sample_payloads/tweet_array.json
+++ b/sample_payloads/tweet_array.json
@@ -1,0 +1,5132 @@
+[
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Mon Jun 01 18:13:12 +0000 2020",
+    "display_text_range": [
+      0,
+      131
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "twitter.com/bailfundnetwor…",
+          "expanded_url": "https://twitter.com/bailfundnetwork/status/1267324806413729792",
+          "indices": [
+            108,
+            131
+          ],
+          "url": "https://t.co/YtDnBiwEve"
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorite_count": 566,
+    "favorited": false,
+    "full_text": "Rust believes that tech is and always will be political- take some time today to invest in your community.\n\nhttps://t.co/YtDnBiwEve",
+    "geo": null,
+    "id": 1267519582505512960,
+    "id_str": "1267519582505512960",
+    "in_reply_to_screen_name": "rustlang",
+    "in_reply_to_status_id": 1267519580756422659,
+    "in_reply_to_status_id_str": "1267519580756422659",
+    "in_reply_to_user_id": 165262228,
+    "in_reply_to_user_id_str": "165262228",
+    "is_quote_status": true,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "quoted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Mon Jun 01 05:19:14 +0000 2020",
+      "display_text_range": [
+        0,
+        290
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              278,
+              290
+            ],
+            "text": "FreeThemAll"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "bit.ly/protestbailfun…",
+            "expanded_url": "http://bit.ly/protestbailfunds",
+            "indices": [
+              253,
+              276
+            ],
+            "url": "https://t.co/nIBai1VIsD"
+          },
+          {
+            "display_url": "twitter.com/bailfundnetwor…",
+            "expanded_url": "https://twitter.com/bailfundnetwork/status/1266760383303319552",
+            "indices": [
+              291,
+              314
+            ],
+            "url": "https://t.co/cebOnYrGKn"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 879,
+      "favorited": false,
+      "full_text": "JUNE 1: This continues to be the ONGOING &amp; UPDATED list of bail funds that are supporting people demanding justice across the country. Please be sure to check this thread for updates/to verify &amp; share widely.\n\nAlso available &amp; updated here: https://t.co/nIBai1VIsD\n\n#FreeThemAll https://t.co/cebOnYrGKn",
+      "geo": null,
+      "id": 1267324806413729792,
+      "id_str": "1267324806413729792",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": true,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "quoted_status_id": 1266760383303319552,
+      "quoted_status_id_str": "1266760383303319552",
+      "quoted_status_permalink": {
+        "display": "twitter.com/bailfundnetwor…",
+        "expanded": "https://twitter.com/bailfundnetwork/status/1266760383303319552",
+        "url": "https://t.co/cebOnYrGKn"
+      },
+      "retweet_count": 1221,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Thu Jun 27 16:29:45 +0000 2019",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "We're a network of over 60 community bail/bond funds that free people from jail and immigration detention & fight to #EndMoneyBail and #EndDetention.",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "bit.ly/localbailfunds",
+                "expanded_url": "http://bit.ly/localbailfunds",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/Fa7Bvits87"
+              }
+            ]
+          }
+        },
+        "favourites_count": 1538,
+        "follow_request_sent": false,
+        "followers_count": 8273,
+        "following": false,
+        "friends_count": 325,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 1144281673443528706,
+        "id_str": "1144281673443528706",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 30,
+        "location": "",
+        "name": "National Bail Fund Network",
+        "notifications": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1144281673443528706/1563294954",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1144288281884057600/8r4BZsVb_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1144288281884057600/8r4BZsVb_normal.png",
+        "profile_link_color": "ABB8C2",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "bailfundnetwork",
+        "statuses_count": 2410,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/Fa7Bvits87",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "quoted_status_id": 1267324806413729792,
+    "quoted_status_id_str": "1267324806413729792",
+    "quoted_status_permalink": {
+      "display": "twitter.com/bailfundnetwor…",
+      "expanded": "https://twitter.com/bailfundnetwork/status/1267324806413729792",
+      "url": "https://t.co/YtDnBiwEve"
+    },
+    "retweet_count": 163,
+    "retweeted": false,
+    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Mon Jun 01 18:13:12 +0000 2020",
+    "display_text_range": [
+      0,
+      222
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorite_count": 1972,
+    "favorited": false,
+    "full_text": "In acknowledgement that taking a stand against police brutality is more important than sharing tech knowledge, this account will pause tweeting until further notice. Feel free to email the core team at: core@rust-lang.org.",
+    "geo": null,
+    "id": 1267519580756422659,
+    "id_str": "1267519580756422659",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 360,
+    "retweeted": false,
+    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 22:29:04 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 32832807,
+          "id_str": "32832807",
+          "indices": [
+            3,
+            15
+          ],
+          "name": "Harald Hoyer",
+          "screen_name": "haraldhoyer"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @haraldhoyer: Created a simple github actions remote runner shim in rust, which enables triggering CI runs on remote servers with the he…",
+    "geo": null,
+    "id": 1266134424036487170,
+    "id_str": "1266134424036487170",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 3,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 22:14:17 +0000 2020",
+      "display_text_range": [
+        0,
+        187
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              170,
+              175
+            ],
+            "text": "rust"
+          },
+          {
+            "indices": [
+              176,
+              183
+            ],
+            "text": "github"
+          },
+          {
+            "indices": [
+              184,
+              187
+            ],
+            "text": "CI"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "github.com/enarx/github-s…",
+            "expanded_url": "https://github.com/enarx/github-ssh-ci-runner",
+            "indices": [
+              134,
+              157
+            ],
+            "url": "https://t.co/jJgVSkDBXQ"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              159,
+              168
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 18,
+      "favorited": false,
+      "full_text": "Created a simple github actions remote runner shim in rust, which enables triggering CI runs on remote servers with the help of ssh.\n\nhttps://t.co/jJgVSkDBXQ\n\n@rustlang  #rust #github #CI",
+      "geo": null,
+      "id": 1266130703407894534,
+      "id_str": "1266130703407894534",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 3,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Sat Apr 18 08:26:52 +0000 2009",
+        "default_profile": true,
+        "default_profile_image": false,
+        "description": "1999-???? @ Red Hat",
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 155,
+        "follow_request_sent": false,
+        "followers_count": 112,
+        "following": false,
+        "friends_count": 126,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 32832807,
+        "id_str": "32832807",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 0,
+        "location": "Vaterstetten, Deutschland",
+        "name": "Harald Hoyer",
+        "notifications": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/32832807/1399916239",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/2201306501/me-cool-rect_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/2201306501/me-cool-rect_normal.jpg",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "haraldhoyer",
+        "statuses_count": 247,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": null,
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 22:28:59 +0000 2020",
+    "display_text_range": [
+      0,
+      131
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "indices": [
+            25,
+            30
+          ],
+          "text": "Rust"
+        }
+      ],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "rust.libhunt.com/newsletter/205",
+          "expanded_url": "https://rust.libhunt.com/newsletter/205",
+          "indices": [
+            50,
+            73
+          ],
+          "url": "https://t.co/RzsiVwaI2Y"
+        }
+      ],
+      "user_mentions": [
+        {
+          "id": 776345944426221568,
+          "id_str": "776345944426221568",
+          "indices": [
+            3,
+            15
+          ],
+          "name": "Rust LibHunt",
+          "screen_name": "RustLibHunt"
+        },
+        {
+          "id": 128700677,
+          "id_str": "128700677",
+          "indices": [
+            84,
+            98
+          ],
+          "name": "Stack Overflow",
+          "screen_name": "StackOverflow"
+        },
+        {
+          "id": 80589255,
+          "id_str": "80589255",
+          "indices": [
+            99,
+            113
+          ],
+          "name": "Open Source Way",
+          "screen_name": "opensourceway"
+        },
+        {
+          "id": 36353475,
+          "id_str": "36353475",
+          "indices": [
+            114,
+            121
+          ],
+          "name": "Cetra",
+          "screen_name": "Cetra3"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            122,
+            131
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @RustLibHunt: Awesome #Rust Weekly #205 is out https://t.co/RzsiVwaI2Y\nFeaturing @stackoverflow @opensourceway @cetra3 @rustlang",
+    "geo": null,
+    "id": 1266134399080415236,
+    "id_str": "1266134399080415236",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "retweet_count": 8,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 22:02:47 +0000 2020",
+      "display_text_range": [
+        0,
+        114
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              8,
+              13
+            ],
+            "text": "Rust"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "rust.libhunt.com/newsletter/205",
+            "expanded_url": "https://rust.libhunt.com/newsletter/205",
+            "indices": [
+              33,
+              56
+            ],
+            "url": "https://t.co/RzsiVwaI2Y"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 128700677,
+            "id_str": "128700677",
+            "indices": [
+              67,
+              81
+            ],
+            "name": "Stack Overflow",
+            "screen_name": "StackOverflow"
+          },
+          {
+            "id": 80589255,
+            "id_str": "80589255",
+            "indices": [
+              82,
+              96
+            ],
+            "name": "Open Source Way",
+            "screen_name": "opensourceway"
+          },
+          {
+            "id": 36353475,
+            "id_str": "36353475",
+            "indices": [
+              97,
+              104
+            ],
+            "name": "Cetra",
+            "screen_name": "Cetra3"
+          },
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              105,
+              114
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 21,
+      "favorited": false,
+      "full_text": "Awesome #Rust Weekly #205 is out https://t.co/RzsiVwaI2Y\nFeaturing @stackoverflow @opensourceway @cetra3 @rustlang",
+      "geo": null,
+      "id": 1266127809589600256,
+      "id_str": "1266127809589600256",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 8,
+      "retweeted": false,
+      "source": "<a href=\"https://www.libhunt.com\" rel=\"nofollow\">LibHunt</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Thu Sep 15 09:04:31 +0000 2016",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Your go-to Rust Toolbox",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "rust.libhunt.com",
+                "expanded_url": "https://rust.libhunt.com",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/UDWWKqrVKW"
+              }
+            ]
+          }
+        },
+        "favourites_count": 2,
+        "follow_request_sent": false,
+        "followers_count": 1184,
+        "following": false,
+        "friends_count": 963,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 776345944426221568,
+        "id_str": "776345944426221568",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 40,
+        "location": "The Internet",
+        "name": "Rust LibHunt",
+        "notifications": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/776346813012074496/S7kCezGv_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/776346813012074496/S7kCezGv_normal.jpg",
+        "profile_link_color": "333333",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "RustLibHunt",
+        "statuses_count": 2224,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/UDWWKqrVKW",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:22:36 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "indices": [
+            20,
+            29
+          ],
+          "text": "rustlang"
+        }
+      ],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 14819336,
+          "id_str": "14819336",
+          "indices": [
+            3,
+            12
+          ],
+          "name": "svartalf",
+          "screen_name": "svartalf"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @svartalf: Today #rustlang nightly introduced the `unused_crate_dependencies` lint, allowing to fail build if there anything unused decl…",
+    "geo": null,
+    "id": 1266102594168131602,
+    "id_str": "1266102594168131602",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 46,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 14:18:45 +0000 2020",
+      "display_text_range": [
+        0,
+        236
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              6,
+              15
+            ],
+            "text": "rustlang"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "github.com/rust-lang/rust…",
+            "expanded_url": "https://github.com/rust-lang/rust/pull/72342",
+            "indices": [
+              213,
+              236
+            ],
+            "url": "https://t.co/e1z1ol82T1"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 261,
+      "favorited": false,
+      "full_text": "Today #rustlang nightly introduced the `unused_crate_dependencies` lint, allowing to fail build if there anything unused declared in Cargo.toml dependencies:\n\nRUSTFLAGS=\"-D unused_crate_dependencies\" cargo check\n\nhttps://t.co/e1z1ol82T1",
+      "geo": null,
+      "id": 1266011029680599044,
+      "id_str": "1266011029680599044",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 46,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Sun May 18 09:23:08 +0000 2008",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Software engineer, making Rust ecosystem better at the moment",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "svartalf.info",
+                "expanded_url": "http://svartalf.info",
+                "indices": [
+                  0,
+                  22
+                ],
+                "url": "http://t.co/hcXEZvThpi"
+              }
+            ]
+          }
+        },
+        "favourites_count": 238,
+        "follow_request_sent": false,
+        "followers_count": 696,
+        "following": false,
+        "friends_count": 25,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 14819336,
+        "id_str": "14819336",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 35,
+        "location": "Saint Petersburg",
+        "name": "svartalf",
+        "notifications": false,
+        "profile_background_color": "022330",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme15/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme15/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1178188024/avatar_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1178188024/avatar_normal.jpg",
+        "profile_link_color": "0084B4",
+        "profile_sidebar_border_color": "A8C7F7",
+        "profile_sidebar_fill_color": "C0DFEC",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "svartalf",
+        "statuses_count": 6980,
+        "time_zone": null,
+        "translator_type": "regular",
+        "url": "http://t.co/hcXEZvThpi",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:22:13 +0000 2020",
+    "display_text_range": [
+      0,
+      79
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "indices": [
+            45,
+            54
+          ],
+          "text": "rustlang"
+        },
+        {
+          "indices": [
+            72,
+            77
+          ],
+          "text": "WSL2"
+        }
+      ],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 21369171,
+          "id_str": "21369171",
+          "indices": [
+            3,
+            14
+          ],
+          "name": "Chris McKenzie",
+          "screen_name": "ISuperGeek"
+        },
+        {
+          "id": 2668989936,
+          "id_str": "2668989936",
+          "indices": [
+            58,
+            68
+          ],
+          "name": "JetBrains CLion IDE",
+          "screen_name": "clion_ide"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @ISuperGeek: What is the current state of #rustlang  + @clion_ide  + #WSL2\n?",
+    "geo": null,
+    "id": 1266102498277953537,
+    "id_str": "1266102498277953537",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 3,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 18:36:36 +0000 2020",
+      "display_text_range": [
+        0,
+        63
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              29,
+              38
+            ],
+            "text": "rustlang"
+          },
+          {
+            "indices": [
+              56,
+              61
+            ],
+            "text": "WSL2"
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 2668989936,
+            "id_str": "2668989936",
+            "indices": [
+              42,
+              52
+            ],
+            "name": "JetBrains CLion IDE",
+            "screen_name": "clion_ide"
+          }
+        ]
+      },
+      "favorite_count": 4,
+      "favorited": false,
+      "full_text": "What is the current state of #rustlang  + @clion_ide  + #WSL2\n?",
+      "geo": null,
+      "id": 1266075918537068545,
+      "id_str": "1266075918537068545",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "retweet_count": 3,
+      "retweeted": false,
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Fri Feb 20 03:17:16 +0000 2009",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Agile developer and Objectivist living and working in downtown Seattle. I've been called the Marie Kondo of Software Engineering.",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "IExtendable.com",
+                "expanded_url": "http://IExtendable.com",
+                "indices": [
+                  0,
+                  22
+                ],
+                "url": "http://t.co/RAwguYdMle"
+              }
+            ]
+          }
+        },
+        "favourites_count": 1081,
+        "follow_request_sent": false,
+        "followers_count": 264,
+        "following": false,
+        "friends_count": 239,
+        "geo_enabled": true,
+        "has_extended_profile": false,
+        "id": 21369171,
+        "id_str": "21369171",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 20,
+        "location": "Seattle, WA",
+        "name": "Chris McKenzie",
+        "notifications": false,
+        "profile_background_color": "131516",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/2182538624/533316_3809757809436_1442190714_33522054_1433777684_n_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/2182538624/533316_3809757809436_1442190714_33522054_1433777684_n_normal.jpg",
+        "profile_link_color": "009999",
+        "profile_sidebar_border_color": "EEEEEE",
+        "profile_sidebar_fill_color": "EFEFEF",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "ISuperGeek",
+        "statuses_count": 5558,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "http://t.co/RAwguYdMle",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:22:08 +0000 2020",
+    "display_text_range": [
+      0,
+      139
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "indices": [
+            36,
+            41
+          ],
+          "text": "MQTT"
+        },
+        {
+          "indices": [
+            42,
+            51
+          ],
+          "text": "rustlang"
+        }
+      ],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 14785423,
+          "id_str": "14785423",
+          "indices": [
+            3,
+            16
+          ],
+          "name": "Kevin Hoffman 🦀",
+          "screen_name": "KevinHoffman"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @KevinHoffman: Anyone know which #MQTT #rustlang crate is the defacto/preferred? There's over a dozen of them and I have no real way of…",
+    "geo": null,
+    "id": 1266102478975746048,
+    "id_str": "1266102478975746048",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 1,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 19:56:52 +0000 2020",
+      "display_text_range": [
+        0,
+        158
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              18,
+              23
+            ],
+            "text": "MQTT"
+          },
+          {
+            "indices": [
+              24,
+              33
+            ],
+            "text": "rustlang"
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorite_count": 17,
+      "favorited": false,
+      "full_text": "Anyone know which #MQTT #rustlang crate is the defacto/preferred? There's over a dozen of them and I have no real way of telling the differences between them.",
+      "geo": null,
+      "id": 1266096121111347200,
+      "id_str": "1266096121111347200",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "retweet_count": 1,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Thu May 15 12:43:26 +0000 2008",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Author, Programming WebAssembly with Rust. I turn napkin drawings into software for @CapitalOne. Distsys nerd. Opinions my own. 中文学生。WeChat: LearnBuildTeach",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "wascc.dev",
+                "expanded_url": "http://wascc.dev",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/emCh3A1ih9"
+              }
+            ]
+          }
+        },
+        "favourites_count": 43082,
+        "follow_request_sent": false,
+        "followers_count": 3120,
+        "following": false,
+        "friends_count": 1736,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 14785423,
+        "id_str": "14785423",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 174,
+        "location": "Earth, Solar System, Milky Way",
+        "name": "Kevin Hoffman 🦀",
+        "notifications": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14785423/1579823902",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1209591762953605121/bS2muj7o_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1209591762953605121/bS2muj7o_normal.jpg",
+        "profile_link_color": "1B95E0",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "KevinHoffman",
+        "statuses_count": 27017,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/emCh3A1ih9",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:21:23 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 770209022,
+          "id_str": "770209022",
+          "indices": [
+            3,
+            11
+          ],
+          "name": "Rüdiger Klaehn",
+          "screen_name": "klaehnr"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            17,
+            26
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @klaehnr: Hey @rustlang twitter: is it possible to write an useful unsized type like str without using unsafe?\n\nBasically something that…",
+    "geo": null,
+    "id": 1266102288331964417,
+    "id_str": "1266102288331964417",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 1,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 19:25:43 +0000 2020",
+      "display_text_range": [
+        0,
+        260
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              4,
+              13
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 10,
+      "favorited": false,
+      "full_text": "Hey @rustlang twitter: is it possible to write an useful unsized type like str without using unsafe?\n\nBasically something that is a refinement of a [u8], just like an utf8 byte sequence...\n\nI checked how from_utf8 works, but it delegates to from_utf8_unsafe...",
+      "geo": null,
+      "id": 1266088279860039683,
+      "id_str": "1266088279860039683",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "retweet_count": 1,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Mon Aug 20 20:53:19 +0000 2012",
+        "default_profile": true,
+        "default_profile_image": false,
+        "description": "Distributed systems engineer at @Actyx, formerly spacecraft telemetry and space mission planning for @Dlr_en",
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 6698,
+        "follow_request_sent": false,
+        "followers_count": 543,
+        "following": false,
+        "friends_count": 848,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 770209022,
+        "id_str": "770209022",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 21,
+        "location": "Bavaria, Germany",
+        "name": "Rüdiger Klaehn",
+        "notifications": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/770209022/1402831077",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1161295627063648256/9DrkHuEB_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1161295627063648256/9DrkHuEB_normal.jpg",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "klaehnr",
+        "statuses_count": 1285,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": null,
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:21:07 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 460544490,
+          "id_str": "460544490",
+          "indices": [
+            3,
+            17
+          ],
+          "name": "Recurse Center",
+          "screen_name": "recursecenter"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            89,
+            98
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        },
+        {
+          "id": 939915987763245056,
+          "id_str": "939915987763245056",
+          "indices": [
+            102,
+            111
+          ],
+          "name": "Wesley Aptekar-Cassels (they/them)",
+          "screen_name": "WAptekar"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": true,
+    "full_text": "RT @recursecenter: An online version of Hanabi, the collaborative card game, built using @rustlang by @WAptekar! \n\nToday's Joy of Computing…",
+    "geo": null,
+    "id": 1266102224264069120,
+    "id_str": "1266102224264069120",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 10,
+    "retweeted": true,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 20:09:44 +0000 2020",
+      "display_text_range": [
+        0,
+        235
+      ],
+      "entities": {
+        "hashtags": [],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/Njjls1cdmW",
+            "expanded_url": "https://twitter.com/recursecenter/status/1266099355695620096/photo/1",
+            "id": 1266099293972303884,
+            "id_str": "1266099293972303884",
+            "indices": [
+              236,
+              259
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZIWmYuXkAwxDaB.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZIWmYuXkAwxDaB.jpg",
+            "sizes": {
+              "large": {
+                "h": 944,
+                "resize": "fit",
+                "w": 1919
+              },
+              "medium": {
+                "h": 590,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 335,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/Njjls1cdmW"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "joy.recurse.com/posts/786-an-o…",
+            "expanded_url": "https://joy.recurse.com/posts/786-an-online-version-of-hanabi",
+            "indices": [
+              122,
+              145
+            ],
+            "url": "https://t.co/3xqOaYgiH7"
+          },
+          {
+            "display_url": "hanabi.site",
+            "expanded_url": "https://hanabi.site",
+            "indices": [
+              180,
+              203
+            ],
+            "url": "https://t.co/ikkWrXdVmL"
+          },
+          {
+            "display_url": "github.com/WesleyAC/hanabi",
+            "expanded_url": "https://github.com/WesleyAC/hanabi",
+            "indices": [
+              212,
+              235
+            ],
+            "url": "https://t.co/DxLWpOi40N"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              70,
+              79
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          },
+          {
+            "id": 939915987763245056,
+            "id_str": "939915987763245056",
+            "indices": [
+              83,
+              92
+            ],
+            "name": "Wesley Aptekar-Cassels (they/them)",
+            "screen_name": "WAptekar"
+          }
+        ]
+      },
+      "extended_entities": {
+        "media": [
+          {
+            "display_url": "pic.twitter.com/Njjls1cdmW",
+            "expanded_url": "https://twitter.com/recursecenter/status/1266099355695620096/photo/1",
+            "id": 1266099293972303884,
+            "id_str": "1266099293972303884",
+            "indices": [
+              236,
+              259
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZIWmYuXkAwxDaB.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZIWmYuXkAwxDaB.jpg",
+            "sizes": {
+              "large": {
+                "h": 944,
+                "resize": "fit",
+                "w": 1919
+              },
+              "medium": {
+                "h": 590,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 335,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/Njjls1cdmW"
+          }
+        ]
+      },
+      "favorite_count": 44,
+      "favorited": true,
+      "full_text": "An online version of Hanabi, the collaborative card game, built using @rustlang by @WAptekar! \n\nToday's Joy of Computing: https://t.co/3xqOaYgiH7\nYou can play with your friends at https://t.co/ikkWrXdVmL\nSource: https://t.co/DxLWpOi40N https://t.co/Njjls1cdmW",
+      "geo": null,
+      "id": 1266099355695620096,
+      "id_str": "1266099355695620096",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 10,
+      "retweeted": true,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Tue Jan 10 21:39:54 +0000 2012",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "RC is a self-directed, community-driven educational retreat for programmers. We believe people learn best when they are free to explore their interests.",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "recurse.com",
+                "expanded_url": "http://www.recurse.com/",
+                "indices": [
+                  0,
+                  22
+                ],
+                "url": "http://t.co/UEvai7Q55k"
+              }
+            ]
+          }
+        },
+        "favourites_count": 1674,
+        "follow_request_sent": false,
+        "followers_count": 26456,
+        "following": false,
+        "friends_count": 156,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 460544490,
+        "id_str": "460544490",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 539,
+        "location": "New York, NY",
+        "name": "Recurse Center",
+        "notifications": false,
+        "profile_background_color": "5ABA47",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme16/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme16/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/460544490/1573673149",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/984166621328617472/5mJw_JYv_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/984166621328617472/5mJw_JYv_normal.jpg",
+        "profile_link_color": "3DC06C",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "recursecenter",
+        "statuses_count": 2540,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "http://t.co/UEvai7Q55k",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 20:21:03 +0000 2020",
+    "display_text_range": [
+      0,
+      139
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 3374358670,
+          "id_str": "3374358670",
+          "indices": [
+            3,
+            11
+          ],
+          "name": "ZomboDB",
+          "screen_name": "zombodb"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @zombodb: It's a little hard to read, but here's standard Rust \"{:?}\" debug output from a safe version of Postgres' raw parse tree, for…",
+    "geo": null,
+    "id": 1266102206857728003,
+    "id_str": "1266102206857728003",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 5,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 20:20:09 +0000 2020",
+      "display_text_range": [
+        0,
+        269
+      ],
+      "entities": {
+        "hashtags": [],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/F7TRhUoHOO",
+            "expanded_url": "https://twitter.com/zombodb/status/1266101980906340353/photo/1",
+            "id": 1266101474452557824,
+            "id_str": "1266101474452557824",
+            "indices": [
+              270,
+              293
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZIYlTpX0AAx5cW.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZIYlTpX0AAx5cW.jpg",
+            "sizes": {
+              "large": {
+                "h": 1361,
+                "resize": "fit",
+                "w": 2048
+              },
+              "medium": {
+                "h": 797,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 452,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/F7TRhUoHOO"
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 848569011231006721,
+            "id_str": "848569011231006721",
+            "indices": [
+              195,
+              206
+            ],
+            "name": "PostgreSQL",
+            "screen_name": "PostgreSQL"
+          },
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              227,
+              236
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "extended_entities": {
+        "media": [
+          {
+            "display_url": "pic.twitter.com/F7TRhUoHOO",
+            "expanded_url": "https://twitter.com/zombodb/status/1266101980906340353/photo/1",
+            "id": 1266101474452557824,
+            "id_str": "1266101474452557824",
+            "indices": [
+              270,
+              293
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZIYlTpX0AAx5cW.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZIYlTpX0AAx5cW.jpg",
+            "sizes": {
+              "large": {
+                "h": 1361,
+                "resize": "fit",
+                "w": 2048
+              },
+              "medium": {
+                "h": 797,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 452,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/F7TRhUoHOO"
+          },
+          {
+            "display_url": "pic.twitter.com/F7TRhUoHOO",
+            "expanded_url": "https://twitter.com/zombodb/status/1266101980906340353/photo/1",
+            "id": 1266101564181221376,
+            "id_str": "1266101564181221376",
+            "indices": [
+              270,
+              293
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZIYqh6WkAArD5F.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZIYqh6WkAArD5F.jpg",
+            "sizes": {
+              "large": {
+                "h": 456,
+                "resize": "fit",
+                "w": 2048
+              },
+              "medium": {
+                "h": 267,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 151,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/F7TRhUoHOO"
+          }
+        ]
+      },
+      "favorite_count": 67,
+      "favorited": false,
+      "full_text": "It's a little hard to read, but here's standard Rust \"{:?}\" debug output from a safe version of Postgres' raw parse tree, for the query \"select ARRAY[1,2,3]\".\n\nIn general, it works!\n\nCan now use @PostgreSQL's query parser from @rustlang.\n\nTesting will be interesting... https://t.co/F7TRhUoHOO",
+      "geo": null,
+      "id": 1266101980906340353,
+      "id_str": "1266101980906340353",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 5,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Mon Jul 13 17:25:28 +0000 2015",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Making #PostgreSQL and #Elasticsearch work together like it's 2020\n\nhttps://t.co/J29nKvoa5o",
+        "entities": {
+          "description": {
+            "urls": [
+              {
+                "display_url": "github.com/sponsors/eeeeb…",
+                "expanded_url": "https://github.com/sponsors/eeeebbbbrrrr",
+                "indices": [
+                  68,
+                  91
+                ],
+                "url": "https://t.co/J29nKvoa5o"
+              }
+            ]
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "zombodb.com",
+                "expanded_url": "http://www.zombodb.com",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/L3ulCseilj"
+              }
+            ]
+          }
+        },
+        "favourites_count": 2719,
+        "follow_request_sent": false,
+        "followers_count": 780,
+        "following": false,
+        "friends_count": 1061,
+        "geo_enabled": false,
+        "has_extended_profile": true,
+        "id": 3374358670,
+        "id_str": "3374358670",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 16,
+        "location": "El Paso, Texas, USA",
+        "name": "ZomboDB",
+        "notifications": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/3374358670/1590899548",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1252126782863675392/Lp3ZqkRF_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1252126782863675392/Lp3ZqkRF_normal.jpg",
+        "profile_link_color": "89C9FA",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "zombodb",
+        "statuses_count": 4969,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/L3ulCseilj",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Thu May 28 01:20:24 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 2978661890,
+          "id_str": "2978661890",
+          "indices": [
+            3,
+            10
+          ],
+          "name": "Kat Marchán 🍑🍑🍑",
+          "screen_name": "zkat__"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            17,
+            26
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @zkat__: Dear @rustlang -- is it possible to, say, read a .toml file that has a struct/trait name in it (or some identifier referring to…",
+    "geo": null,
+    "id": 1265815151275651072,
+    "id_str": "1265815151275651072",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 1,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Thu May 28 01:13:45 +0000 2020",
+      "display_text_range": [
+        0,
+        269
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "build.rs",
+            "expanded_url": "http://build.rs",
+            "indices": [
+              245,
+              268
+            ],
+            "url": "https://t.co/JgIydbgI8h"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              5,
+              14
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 16,
+      "favorited": false,
+      "full_text": "Dear @rustlang -- is it possible to, say, read a .toml file that has a struct/trait name in it (or some identifier referring to one), and have some code that creates an instance of that struct dynamically? *Without* dynamic code generation with https://t.co/JgIydbgI8h?",
+      "geo": null,
+      "id": 1265813479375532032,
+      "id_str": "1265813479375532032",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 1,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Tue Jan 13 06:07:49 +0000 2015",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "tired of tech. edeleth stan account. nb. (they/them), boricua, eng @microsoft. 🐘: @zkat@toot.cat. shitposts and opinions my own.",
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 151232,
+        "follow_request_sent": false,
+        "followers_count": 11086,
+        "following": false,
+        "friends_count": 375,
+        "geo_enabled": false,
+        "has_extended_profile": true,
+        "id": 2978661890,
+        "id_str": "2978661890",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 362,
+        "location": "Oakland, CA",
+        "name": "Kat Marchán 🍑🍑🍑",
+        "notifications": false,
+        "profile_background_color": "352726",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme5/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme5/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/2978661890/1590861083",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1192876597730168832/csEZmgJb_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1192876597730168832/csEZmgJb_normal.jpg",
+        "profile_link_color": "19CF86",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "zkat__",
+        "statuses_count": 71734,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": null,
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 23:29:57 +0000 2020",
+    "display_text_range": [
+      0,
+      75
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "indices": [
+            66,
+            75
+          ],
+          "text": "rustlang"
+        }
+      ],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "this-week-in-rust.org/blog/2020/05/2…",
+          "expanded_url": "https://this-week-in-rust.org/blog/2020/05/27/this-week-in-rust-340/",
+          "indices": [
+            42,
+            65
+          ],
+          "url": "https://t.co/KljR2E52Ue"
+        }
+      ],
+      "user_mentions": [
+        {
+          "id": 3252451501,
+          "id_str": "3252451501",
+          "indices": [
+            3,
+            18
+          ],
+          "name": "This Week in Rust",
+          "screen_name": "ThisWeekInRust"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @ThisWeekInRust: This week in Rust 340 https://t.co/KljR2E52Ue #rustlang",
+    "geo": null,
+    "id": 1265787353878212609,
+    "id_str": "1265787353878212609",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "retweet_count": 16,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 20:51:04 +0000 2020",
+      "display_text_range": [
+        0,
+        55
+      ],
+      "entities": {
+        "hashtags": [
+          {
+            "indices": [
+              46,
+              55
+            ],
+            "text": "rustlang"
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "this-week-in-rust.org/blog/2020/05/2…",
+            "expanded_url": "https://this-week-in-rust.org/blog/2020/05/27/this-week-in-rust-340/",
+            "indices": [
+              22,
+              45
+            ],
+            "url": "https://t.co/KljR2E52Ue"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 50,
+      "favorited": false,
+      "full_text": "This week in Rust 340 https://t.co/KljR2E52Ue #rustlang",
+      "geo": null,
+      "id": 1265747370488115200,
+      "id_str": "1265747370488115200",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 16,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Mon Jun 22 06:48:22 +0000 2015",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Cataloguing the Rust community's awesomeness #rustlang",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "this-week-in-rust.org",
+                "expanded_url": "http://this-week-in-rust.org/",
+                "indices": [
+                  0,
+                  22
+                ],
+                "url": "http://t.co/ZBRtt41QwX"
+              }
+            ]
+          }
+        },
+        "favourites_count": 90,
+        "follow_request_sent": false,
+        "followers_count": 15013,
+        "following": false,
+        "friends_count": 34,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 3252451501,
+        "id_str": "3252451501",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 284,
+        "location": "Pale Blue Dot",
+        "name": "This Week in Rust",
+        "notifications": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/633365450760458240/SpZ17g_B_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/633365450760458240/SpZ17g_B_normal.png",
+        "profile_link_color": "777777",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "000000",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "ThisWeekInRust",
+        "statuses_count": 1989,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "http://t.co/ZBRtt41QwX",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 23:29:40 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 25386045,
+          "id_str": "25386045",
+          "indices": [
+            3,
+            10
+          ],
+          "name": "Jon Gjengset",
+          "screen_name": "jonhoo"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            37,
+            46
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @jonhoo: Today's Crust of Rust on @rustlang iterators and trait bounds is now on YouTube, fresh out of the oven (literally; my apartment…",
+    "geo": null,
+    "id": 1265787282977689600,
+    "id_str": "1265787282977689600",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 18,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 22:54:59 +0000 2020",
+      "display_text_range": [
+        0,
+        254
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "youtube.com/watch?v=yozQ9C…",
+            "expanded_url": "https://www.youtube.com/watch?v=yozQ9C69pNs",
+            "indices": [
+              231,
+              254
+            ],
+            "url": "https://t.co/VZZQWvawhA"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              25,
+              34
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 141,
+      "favorited": false,
+      "full_text": "Today's Crust of Rust on @rustlang iterators and trait bounds is now on YouTube, fresh out of the oven (literally; my apartment was ~95°F at the end). We re-implemented Iterator::flatten, including the DoubleEndedIterator parts! 🥧 https://t.co/VZZQWvawhA",
+      "geo": null,
+      "id": 1265778554782060544,
+      "id_str": "1265778554782060544",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 18,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Thu Mar 19 21:12:36 +0000 2009",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "PhD student at MIT in distributed systems, @rustlang live-coder. and OSS tinkerer who loves teaching. I try to maintain a high SNR and retweet original tweets!",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "thesquareplanet.com",
+                "expanded_url": "https://thesquareplanet.com",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/Of7xpxXqvx"
+              }
+            ]
+          }
+        },
+        "favourites_count": 11285,
+        "follow_request_sent": false,
+        "followers_count": 6475,
+        "following": false,
+        "friends_count": 142,
+        "geo_enabled": true,
+        "has_extended_profile": true,
+        "id": 25386045,
+        "id_str": "25386045",
+        "is_translation_enabled": true,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 99,
+        "location": "Cambridge, Massachusetts",
+        "name": "Jon Gjengset",
+        "notifications": false,
+        "profile_background_color": "89C9FA",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme18/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme18/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/25386045/1489783222",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+        "profile_link_color": "0C6FA9",
+        "profile_sidebar_border_color": "C6E2EE",
+        "profile_sidebar_fill_color": "DAECF4",
+        "profile_text_color": "663B12",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "jonhoo",
+        "statuses_count": 5188,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/Of7xpxXqvx",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 21:15:30 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "crates.io",
+          "expanded_url": "http://crates.io",
+          "indices": [
+            72,
+            95
+          ],
+          "url": "https://t.co/a3X2IvcNBX"
+        }
+      ],
+      "user_mentions": [
+        {
+          "id": 1261362116377800706,
+          "id_str": "1261362116377800706",
+          "indices": [
+            3,
+            15
+          ],
+          "name": "rain 🌧",
+          "screen_name": "sunshowers6"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            49,
+            58
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @sunshowers6: What is the semver contract for @rustlang CLI tools on https://t.co/a3X2IvcNBX?\n* I guess the CLI is the API so any breaki…",
+    "geo": null,
+    "id": 1265753518432047104,
+    "id_str": "1265753518432047104",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "retweet_count": 1,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 17:36:24 +0000 2020",
+      "display_text_range": [
+        0,
+        275
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "crates.io",
+            "expanded_url": "http://crates.io",
+            "indices": [
+              55,
+              78
+            ],
+            "url": "https://t.co/a3X2IvcNBX"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              32,
+              41
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 12,
+      "favorited": false,
+      "full_text": "What is the semver contract for @rustlang CLI tools on https://t.co/a3X2IvcNBX?\n* I guess the CLI is the API so any breaking changes to it would involve a new major version?\n* Do I need to care about users who use the crate as a library if I explicitly document not to do it?",
+      "geo": null,
+      "id": 1265698384230285314,
+      "id_str": "1265698384230285314",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 1,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Fri May 15 18:26:08 +0000 2020",
+        "default_profile": true,
+        "default_profile_image": false,
+        "description": "domain modeler. they/she. queer ⋀ trans. rust is cool. tweets are solely my fault. black lives matter",
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 106,
+        "follow_request_sent": false,
+        "followers_count": 281,
+        "following": false,
+        "friends_count": 75,
+        "geo_enabled": false,
+        "has_extended_profile": true,
+        "id": 1261362116377800706,
+        "id_str": "1261362116377800706",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 4,
+        "location": "Oakland, CA",
+        "name": "rain 🌧",
+        "notifications": false,
+        "profile_background_color": "F5F8FA",
+        "profile_background_image_url": null,
+        "profile_background_image_url_https": null,
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1267872149768769536/a7uH8eO__normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1267872149768769536/a7uH8eO__normal.jpg",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "sunshowers6",
+        "statuses_count": 91,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": null,
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 21:15:15 +0000 2020",
+    "display_text_range": [
+      0,
+      139
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "actyx.com/news/2020/5/25…",
+          "expanded_url": "https://www.actyx.com/news/2020/5/25/may-2020-release-update",
+          "indices": [
+            86,
+            109
+          ],
+          "url": "https://t.co/Tk1Ewett88"
+        }
+      ],
+      "user_mentions": [
+        {
+          "id": 770209022,
+          "id_str": "770209022",
+          "indices": [
+            3,
+            11
+          ],
+          "name": "Rüdiger Klaehn",
+          "screen_name": "klaehnr"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            128,
+            137
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @klaehnr: Want to use p2p technology in manufacturing?\n\nWe released RC2 of ActyxOS\nhttps://t.co/Tk1Ewett88\n\nCore is built in @rustlang,…",
+    "geo": null,
+    "id": 1265753456003952641,
+    "id_str": "1265753456003952641",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "retweet_count": 10,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 08:39:23 +0000 2020",
+      "display_text_range": [
+        0,
+        263
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "actyx.com/news/2020/5/25…",
+            "expanded_url": "https://www.actyx.com/news/2020/5/25/may-2020-release-update",
+            "indices": [
+              73,
+              96
+            ],
+            "url": "https://t.co/Tk1Ewett88"
+          },
+          {
+            "display_url": "crates.io/crates/actyxos…",
+            "expanded_url": "https://crates.io/crates/actyxos_sdk",
+            "indices": [
+              240,
+              263
+            ],
+            "url": "https://t.co/qCIbo9C7Zu"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              115,
+              124
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          },
+          {
+            "id": 809233214,
+            "id_str": "809233214",
+            "indices": [
+              155,
+              166
+            ],
+            "name": "TypeScript",
+            "screen_name": "typescript"
+          },
+          {
+            "id": 1266081387179847683,
+            "id_str": "1266081387179847683",
+            "indices": [
+              183,
+              191
+            ],
+            "name": "IPFSbot",
+            "screen_name": "IpfSbot"
+          },
+          {
+            "id": 778395996619431937,
+            "id_str": "778395996619431937",
+            "indices": [
+              194,
+              201
+            ],
+            "name": "libp2p",
+            "screen_name": "libp2p"
+          }
+        ]
+      },
+      "favorite_count": 26,
+      "favorited": false,
+      "full_text": "Want to use p2p technology in manufacturing?\n\nWe released RC2 of ActyxOS\nhttps://t.co/Tk1Ewett88\n\nCore is built in @rustlang, business logic is written in @typescript. Networking via @ipfsbot / @libp2p.\n\nAlso, Rust API for high perf needs:\nhttps://t.co/qCIbo9C7Zu",
+      "geo": null,
+      "id": 1265563236197416960,
+      "id_str": "1265563236197416960",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 10,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Mon Aug 20 20:53:19 +0000 2012",
+        "default_profile": true,
+        "default_profile_image": false,
+        "description": "Distributed systems engineer at @Actyx, formerly spacecraft telemetry and space mission planning for @Dlr_en",
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 6698,
+        "follow_request_sent": false,
+        "followers_count": 543,
+        "following": false,
+        "friends_count": 848,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 770209022,
+        "id_str": "770209022",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 21,
+        "location": "Bavaria, Germany",
+        "name": "Rüdiger Klaehn",
+        "notifications": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/770209022/1402831077",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1161295627063648256/9DrkHuEB_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1161295627063648256/9DrkHuEB_normal.jpg",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "klaehnr",
+        "statuses_count": 1285,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": null,
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 21:13:49 +0000 2020",
+    "display_text_range": [
+      0,
+      85
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "display_url": "twitter.com/jonhoo/status/…",
+          "expanded_url": "https://twitter.com/jonhoo/status/1265285360101318656",
+          "indices": [
+            62,
+            85
+          ],
+          "url": "https://t.co/bm5RelJHGm"
+        }
+      ],
+      "user_mentions": [
+        {
+          "id": 25386045,
+          "id_str": "25386045",
+          "indices": [
+            3,
+            10
+          ],
+          "name": "Jon Gjengset",
+          "screen_name": "jonhoo"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @jonhoo: Quick reminder that this is happening in 6 hours!\nhttps://t.co/bm5RelJHGm",
+    "geo": null,
+    "id": 1265753096745095168,
+    "id_str": "1265753096745095168",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": true,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "quoted_status_id": 1265285360101318656,
+    "quoted_status_id_str": "1265285360101318656",
+    "quoted_status_permalink": {
+      "display": "twitter.com/jonhoo/status/…",
+      "expanded": "https://twitter.com/jonhoo/status/1265285360101318656",
+      "url": "https://t.co/bm5RelJHGm"
+    },
+    "retweet_count": 4,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 14:30:10 +0000 2020",
+      "display_text_range": [
+        0,
+        73
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "twitter.com/jonhoo/status/…",
+            "expanded_url": "https://twitter.com/jonhoo/status/1265285360101318656",
+            "indices": [
+              50,
+              73
+            ],
+            "url": "https://t.co/bm5RelJHGm"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 35,
+      "favorited": false,
+      "full_text": "Quick reminder that this is happening in 6 hours!\nhttps://t.co/bm5RelJHGm",
+      "geo": null,
+      "id": 1265651515496247296,
+      "id_str": "1265651515496247296",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": true,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "quoted_status": {
+        "contributors": null,
+        "coordinates": null,
+        "created_at": "Tue May 26 14:15:12 +0000 2020",
+        "display_text_range": [
+          0,
+          214
+        ],
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "urls": [
+            {
+              "display_url": "everytimezone.com/s/c5814c1f",
+              "expanded_url": "https://everytimezone.com/s/c5814c1f",
+              "indices": [
+                113,
+                136
+              ],
+              "url": "https://t.co/yNNIm97UNM"
+            },
+            {
+              "display_url": "twitter.com/jonhoo/status/…",
+              "expanded_url": "https://twitter.com/jonhoo/status/1264906113939574786",
+              "indices": [
+                191,
+                214
+              ],
+              "url": "https://t.co/ih3WiqclsF"
+            }
+          ],
+          "user_mentions": [
+            {
+              "id": 165262228,
+              "id_str": "165262228",
+              "indices": [
+                76,
+                85
+              ],
+              "name": "Rust Language",
+              "screen_name": "rustlang"
+            }
+          ]
+        },
+        "favorite_count": 56,
+        "favorited": false,
+        "full_text": "The votes are in! Tomorrow's Crust of Rust on Iterators and trait bounds in @rustlang will happen at 8:30pm UTC (https://t.co/yNNIm97UNM), just like the past few streams. Come one, come all! https://t.co/ih3WiqclsF",
+        "geo": null,
+        "id": 1265285360101318656,
+        "id_str": "1265285360101318656",
+        "in_reply_to_screen_name": null,
+        "in_reply_to_status_id": null,
+        "in_reply_to_status_id_str": null,
+        "in_reply_to_user_id": null,
+        "in_reply_to_user_id_str": null,
+        "is_quote_status": true,
+        "lang": "en",
+        "place": null,
+        "possibly_sensitive": false,
+        "quoted_status_id": 1264906113939574786,
+        "quoted_status_id_str": "1264906113939574786",
+        "quoted_status_permalink": {
+          "display": "twitter.com/jonhoo/status/…",
+          "expanded": "https://twitter.com/jonhoo/status/1264906113939574786",
+          "url": "https://t.co/ih3WiqclsF"
+        },
+        "retweet_count": 8,
+        "retweeted": false,
+        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+        "truncated": false,
+        "user": {
+          "contributors_enabled": false,
+          "created_at": "Thu Mar 19 21:12:36 +0000 2009",
+          "default_profile": false,
+          "default_profile_image": false,
+          "description": "PhD student at MIT in distributed systems, @rustlang live-coder. and OSS tinkerer who loves teaching. I try to maintain a high SNR and retweet original tweets!",
+          "entities": {
+            "description": {
+              "urls": []
+            },
+            "url": {
+              "urls": [
+                {
+                  "display_url": "thesquareplanet.com",
+                  "expanded_url": "https://thesquareplanet.com",
+                  "indices": [
+                    0,
+                    23
+                  ],
+                  "url": "https://t.co/Of7xpxXqvx"
+                }
+              ]
+            }
+          },
+          "favourites_count": 11285,
+          "follow_request_sent": false,
+          "followers_count": 6475,
+          "following": false,
+          "friends_count": 142,
+          "geo_enabled": true,
+          "has_extended_profile": true,
+          "id": 25386045,
+          "id_str": "25386045",
+          "is_translation_enabled": true,
+          "is_translator": false,
+          "lang": null,
+          "listed_count": 99,
+          "location": "Cambridge, Massachusetts",
+          "name": "Jon Gjengset",
+          "notifications": false,
+          "profile_background_color": "89C9FA",
+          "profile_background_image_url": "http://abs.twimg.com/images/themes/theme18/bg.gif",
+          "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme18/bg.gif",
+          "profile_background_tile": false,
+          "profile_banner_url": "https://pbs.twimg.com/profile_banners/25386045/1489783222",
+          "profile_image_url": "http://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+          "profile_image_url_https": "https://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+          "profile_link_color": "0C6FA9",
+          "profile_sidebar_border_color": "C6E2EE",
+          "profile_sidebar_fill_color": "DAECF4",
+          "profile_text_color": "663B12",
+          "profile_use_background_image": true,
+          "protected": false,
+          "screen_name": "jonhoo",
+          "statuses_count": 5188,
+          "time_zone": null,
+          "translator_type": "none",
+          "url": "https://t.co/Of7xpxXqvx",
+          "utc_offset": null,
+          "verified": false
+        }
+      },
+      "quoted_status_id": 1265285360101318656,
+      "quoted_status_id_str": "1265285360101318656",
+      "quoted_status_permalink": {
+        "display": "twitter.com/jonhoo/status/…",
+        "expanded": "https://twitter.com/jonhoo/status/1265285360101318656",
+        "url": "https://t.co/bm5RelJHGm"
+      },
+      "retweet_count": 4,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Thu Mar 19 21:12:36 +0000 2009",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "PhD student at MIT in distributed systems, @rustlang live-coder. and OSS tinkerer who loves teaching. I try to maintain a high SNR and retweet original tweets!",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "thesquareplanet.com",
+                "expanded_url": "https://thesquareplanet.com",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/Of7xpxXqvx"
+              }
+            ]
+          }
+        },
+        "favourites_count": 11285,
+        "follow_request_sent": false,
+        "followers_count": 6475,
+        "following": false,
+        "friends_count": 142,
+        "geo_enabled": true,
+        "has_extended_profile": true,
+        "id": 25386045,
+        "id_str": "25386045",
+        "is_translation_enabled": true,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 99,
+        "location": "Cambridge, Massachusetts",
+        "name": "Jon Gjengset",
+        "notifications": false,
+        "profile_background_color": "89C9FA",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme18/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme18/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/25386045/1489783222",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1114594272077066240/86ze0W_P_normal.png",
+        "profile_link_color": "0C6FA9",
+        "profile_sidebar_border_color": "C6E2EE",
+        "profile_sidebar_fill_color": "DAECF4",
+        "profile_text_color": "663B12",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "jonhoo",
+        "statuses_count": 5188,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/Of7xpxXqvx",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 21:13:28 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 386654463,
+          "id_str": "386654463",
+          "indices": [
+            3,
+            16
+          ],
+          "name": "Niko Matsakis",
+          "screen_name": "nikomatsakis"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            87,
+            96
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": true,
+    "full_text": "RT @nikomatsakis: Ever contributed code -- or thought about contributing code -- to an @rustlang repo? Fill out this survey to help us unde…",
+    "geo": null,
+    "id": 1265753010413633538,
+    "id_str": "1265753010413633538",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 56,
+    "retweeted": true,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 20:47:26 +0000 2020",
+      "display_text_range": [
+        0,
+        186
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "blog.rust-lang.org/inside-rust/20…",
+            "expanded_url": "https://blog.rust-lang.org/inside-rust/2020/05/27/contributor-survey.html",
+            "indices": [
+              163,
+              186
+            ],
+            "url": "https://t.co/w3H2E3gSFr"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              69,
+              78
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 104,
+      "favorited": true,
+      "full_text": "Ever contributed code -- or thought about contributing code -- to an @rustlang repo? Fill out this survey to help us understand how we can improve the experience! https://t.co/w3H2E3gSFr",
+      "geo": null,
+      "id": 1265746457476444160,
+      "id_str": "1265746457476444160",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 56,
+      "retweeted": true,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Fri Oct 07 17:15:21 +0000 2011",
+        "default_profile": true,
+        "default_profile_image": false,
+        "description": "Rustacean. him/they.",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "smallcultfollowing.com/babysteps",
+                "expanded_url": "http://smallcultfollowing.com/babysteps",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/4tSJb6bZRW"
+              }
+            ]
+          }
+        },
+        "favourites_count": 2760,
+        "follow_request_sent": false,
+        "followers_count": 6865,
+        "following": true,
+        "friends_count": 318,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 386654463,
+        "id_str": "386654463",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 164,
+        "location": "Boston, MA",
+        "name": "Niko Matsakis",
+        "notifications": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/386654463/1553608252",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1110539492706914304/NUeyOrLX_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1110539492706914304/NUeyOrLX_normal.png",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "nikomatsakis",
+        "statuses_count": 928,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/4tSJb6bZRW",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 13:00:27 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 20247424,
+          "id_str": "20247424",
+          "indices": [
+            3,
+            13
+          ],
+          "name": "Simon Paitrault",
+          "screen_name": "Freyskeyd"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            19,
+            28
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @Freyskeyd: Hey @rustlang folks 🦀\n\nI’m starting a blog post series about how I’m trying to implement an open source cqrs/es library from…",
+    "geo": null,
+    "id": 1265628936395984897,
+    "id_str": "1265628936395984897",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 8,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 09:17:56 +0000 2020",
+      "display_text_range": [
+        0,
+        256
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              4,
+              13
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "favorite_count": 79,
+      "favorited": false,
+      "full_text": "Hey @rustlang folks 🦀\n\nI’m starting a blog post series about how I’m trying to implement an open source cqrs/es library from scratch. \n\nI want that to be collaborative so feel free to ask or participate! \n\nIs it something that might interest some of you? 🥰",
+      "geo": null,
+      "id": 1265572937584840704,
+      "id_str": "1265572937584840704",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "retweet_count": 8,
+      "retweeted": false,
+      "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Fri Feb 06 16:07:25 +0000 2009",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "PLATFORM Engineer @iAdvize. FullStack Software engineer, Photographer, @rustlang enthusiast, #devops, FP, travel geek, animals defender and some other things",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "freyskeyd.fr",
+                "expanded_url": "http://www.freyskeyd.fr",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/KhiPZcvgfM"
+              }
+            ]
+          }
+        },
+        "favourites_count": 464,
+        "follow_request_sent": false,
+        "followers_count": 280,
+        "following": false,
+        "friends_count": 174,
+        "geo_enabled": true,
+        "has_extended_profile": true,
+        "id": 20247424,
+        "id_str": "20247424",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 15,
+        "location": "Nantes",
+        "name": "Simon Paitrault",
+        "notifications": false,
+        "profile_background_color": "333333",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/20247424/1391417602",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/962278871574949888/-E2MR3u5_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/962278871574949888/-E2MR3u5_normal.jpg",
+        "profile_link_color": "019AD2",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "Freyskeyd",
+        "statuses_count": 3129,
+        "time_zone": null,
+        "translator_type": "regular",
+        "url": "https://t.co/KhiPZcvgfM",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 13:00:18 +0000 2020",
+    "display_text_range": [
+      0,
+      123
+    ],
+    "entities": {
+      "hashtags": [],
+      "media": [
+        {
+          "display_url": "pic.twitter.com/7Kse3SyL5u",
+          "expanded_url": "https://twitter.com/piecritic/status/1265598567126896641/photo/1",
+          "id": 1265598549254955008,
+          "id_str": "1265598549254955008",
+          "indices": [
+            100,
+            123
+          ],
+          "media_url": "http://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+          "sizes": {
+            "large": {
+              "h": 104,
+              "resize": "fit",
+              "w": 1366
+            },
+            "medium": {
+              "h": 91,
+              "resize": "fit",
+              "w": 1200
+            },
+            "small": {
+              "h": 52,
+              "resize": "fit",
+              "w": 680
+            },
+            "thumb": {
+              "h": 104,
+              "resize": "crop",
+              "w": 104
+            }
+          },
+          "source_status_id": 1265598567126896641,
+          "source_status_id_str": "1265598567126896641",
+          "source_user_id": 17752201,
+          "source_user_id_str": "17752201",
+          "type": "photo",
+          "url": "https://t.co/7Kse3SyL5u"
+        }
+      ],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 17752201,
+          "id_str": "17752201",
+          "indices": [
+            3,
+            13
+          ],
+          "name": "Brendan Molloy",
+          "screen_name": "piecritic"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            15,
+            24
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        }
+      ]
+    },
+    "extended_entities": {
+      "media": [
+        {
+          "display_url": "pic.twitter.com/7Kse3SyL5u",
+          "expanded_url": "https://twitter.com/piecritic/status/1265598567126896641/photo/1",
+          "id": 1265598549254955008,
+          "id_str": "1265598549254955008",
+          "indices": [
+            100,
+            123
+          ],
+          "media_url": "http://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+          "sizes": {
+            "large": {
+              "h": 104,
+              "resize": "fit",
+              "w": 1366
+            },
+            "medium": {
+              "h": 91,
+              "resize": "fit",
+              "w": 1200
+            },
+            "small": {
+              "h": 52,
+              "resize": "fit",
+              "w": 680
+            },
+            "thumb": {
+              "h": 104,
+              "resize": "crop",
+              "w": 104
+            }
+          },
+          "source_status_id": 1265598567126896641,
+          "source_status_id_str": "1265598567126896641",
+          "source_user_id": 17752201,
+          "source_user_id_str": "17752201",
+          "type": "photo",
+          "url": "https://t.co/7Kse3SyL5u"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @piecritic: @rustlang on a scale of 1 to 10, how illegal is this ultracrime in the unsafe lands? https://t.co/7Kse3SyL5u",
+    "geo": null,
+    "id": 1265628900081700865,
+    "id_str": "1265628900081700865",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "retweet_count": 3,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 10:59:46 +0000 2020",
+      "display_text_range": [
+        0,
+        84
+      ],
+      "entities": {
+        "hashtags": [],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/7Kse3SyL5u",
+            "expanded_url": "https://twitter.com/piecritic/status/1265598567126896641/photo/1",
+            "id": 1265598549254955008,
+            "id_str": "1265598549254955008",
+            "indices": [
+              85,
+              108
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+            "sizes": {
+              "large": {
+                "h": 104,
+                "resize": "fit",
+                "w": 1366
+              },
+              "medium": {
+                "h": 91,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 52,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 104,
+                "resize": "crop",
+                "w": 104
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/7Kse3SyL5u"
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              0,
+              9
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          }
+        ]
+      },
+      "extended_entities": {
+        "media": [
+          {
+            "display_url": "pic.twitter.com/7Kse3SyL5u",
+            "expanded_url": "https://twitter.com/piecritic/status/1265598567126896641/photo/1",
+            "id": 1265598549254955008,
+            "id_str": "1265598549254955008",
+            "indices": [
+              85,
+              108
+            ],
+            "media_url": "http://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/EZBPLNSXYAA9AiU.jpg",
+            "sizes": {
+              "large": {
+                "h": 104,
+                "resize": "fit",
+                "w": 1366
+              },
+              "medium": {
+                "h": 91,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 52,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 104,
+                "resize": "crop",
+                "w": 104
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/7Kse3SyL5u"
+          }
+        ]
+      },
+      "favorite_count": 12,
+      "favorited": false,
+      "full_text": "@rustlang on a scale of 1 to 10, how illegal is this ultracrime in the unsafe lands? https://t.co/7Kse3SyL5u",
+      "geo": null,
+      "id": 1265598567126896641,
+      "id_str": "1265598567126896641",
+      "in_reply_to_screen_name": "rustlang",
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": 165262228,
+      "in_reply_to_user_id_str": "165262228",
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 3,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Sun Nov 30 10:20:45 +0000 2008",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "Rust is my first language now. Former Australian. Working at @technocreatives. I do language tech for Sámi and other indigenous peoples.",
+        "entities": {
+          "description": {
+            "urls": []
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "brendan.se",
+                "expanded_url": "http://brendan.se",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/eBwGx5a7kc"
+              }
+            ]
+          }
+        },
+        "favourites_count": 2161,
+        "follow_request_sent": false,
+        "followers_count": 1867,
+        "following": false,
+        "friends_count": 326,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 17752201,
+        "id_str": "17752201",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 124,
+        "location": "Gothenburg, Sweden",
+        "name": "Brendan Molloy",
+        "notifications": false,
+        "profile_background_color": "1A1B1F",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/17752201/1526284353",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1185965792581607426/HZmnPhMP_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1185965792581607426/HZmnPhMP_normal.jpg",
+        "profile_link_color": "0073AE",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "252429",
+        "profile_text_color": "666666",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "piecritic",
+        "statuses_count": 81209,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/eBwGx5a7kc",
+        "utc_offset": null,
+        "verified": false
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  },
+  {
+    "contributors": null,
+    "coordinates": null,
+    "created_at": "Wed May 27 13:00:06 +0000 2020",
+    "display_text_range": [
+      0,
+      140
+    ],
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 14288184,
+          "id_str": "14288184",
+          "indices": [
+            3,
+            12
+          ],
+          "name": "Smarkets",
+          "screen_name": "smarkets"
+        },
+        {
+          "id": 165262228,
+          "id_str": "165262228",
+          "indices": [
+            41,
+            50
+          ],
+          "name": "Rust Language",
+          "screen_name": "rustlang"
+        },
+        {
+          "id": 1049228648660815872,
+          "id_str": "1049228648660815872",
+          "indices": [
+            98,
+            111
+          ],
+          "name": "RustLDN",
+          "screen_name": "RustLdnUsers"
+        }
+      ]
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "full_text": "RT @smarkets: If you have an interest in @rustlang, then make sure you join us for this evening’s @RustLdnUsers virtual meet-up (feat. @Tru…",
+    "geo": null,
+    "id": 1265628849343168513,
+    "id_str": "1265628849343168513",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "retweet_count": 6,
+    "retweeted": false,
+    "retweeted_status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed May 27 11:26:00 +0000 2020",
+      "display_text_range": [
+        0,
+        192
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "smrkts.co/3c1gJfm",
+            "expanded_url": "https://smrkts.co/3c1gJfm",
+            "indices": [
+              169,
+              192
+            ],
+            "url": "https://t.co/wAWbf7NClJ"
+          }
+        ],
+        "user_mentions": [
+          {
+            "id": 165262228,
+            "id_str": "165262228",
+            "indices": [
+              27,
+              36
+            ],
+            "name": "Rust Language",
+            "screen_name": "rustlang"
+          },
+          {
+            "id": 1049228648660815872,
+            "id_str": "1049228648660815872",
+            "indices": [
+              84,
+              97
+            ],
+            "name": "RustLDN",
+            "screen_name": "RustLdnUsers"
+          },
+          {
+            "id": 775651057011744768,
+            "id_str": "775651057011744768",
+            "indices": [
+              121,
+              131
+            ],
+            "name": "TrueLayer",
+            "screen_name": "TrueLayer"
+          },
+          {
+            "id": 2739826012,
+            "id_str": "2739826012",
+            "indices": [
+              138,
+              151
+            ],
+            "name": "Matrix",
+            "screen_name": "matrixdotorg"
+          }
+        ]
+      },
+      "favorite_count": 8,
+      "favorited": false,
+      "full_text": "If you have an interest in @rustlang, then make sure you join us for this evening’s @RustLdnUsers virtual meet-up (feat. @TrueLayer &amp; @matrixdotorg)\n\nRegister here: https://t.co/wAWbf7NClJ",
+      "geo": null,
+      "id": 1265605166633451521,
+      "id_str": "1265605166633451521",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 6,
+      "retweeted": false,
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "user": {
+        "contributors_enabled": false,
+        "created_at": "Wed Apr 02 22:25:18 +0000 2008",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "The best of sports betting, political prediction markets and fintech in one sleek, 2% commission exchange. DMs open. Followers must be 18+. https://t.co/p6nDJkCOUM",
+        "entities": {
+          "description": {
+            "urls": [
+              {
+                "display_url": "Begambleaware.org",
+                "expanded_url": "http://Begambleaware.org",
+                "indices": [
+                  140,
+                  163
+                ],
+                "url": "https://t.co/p6nDJkCOUM"
+              }
+            ]
+          },
+          "url": {
+            "urls": [
+              {
+                "display_url": "smarkets.com",
+                "expanded_url": "http://smarkets.com",
+                "indices": [
+                  0,
+                  23
+                ],
+                "url": "https://t.co/CrD60C7hI5"
+              }
+            ]
+          }
+        },
+        "favourites_count": 1500,
+        "follow_request_sent": false,
+        "followers_count": 10554,
+        "following": false,
+        "friends_count": 600,
+        "geo_enabled": true,
+        "has_extended_profile": false,
+        "id": 14288184,
+        "id_str": "14288184",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": null,
+        "listed_count": 175,
+        "location": "London",
+        "name": "Smarkets",
+        "notifications": false,
+        "profile_background_color": "00B677",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14288184/1584124332",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1214492873602850816/dGNCSjzG_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1214492873602850816/dGNCSjzG_normal.jpg",
+        "profile_link_color": "0CCD93",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "EBEBEB",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "protected": false,
+        "screen_name": "smarkets",
+        "statuses_count": 18150,
+        "time_zone": null,
+        "translator_type": "none",
+        "url": "https://t.co/CrD60C7hI5",
+        "utc_offset": null,
+        "verified": true
+      }
+    },
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "user": {
+      "contributors_enabled": false,
+      "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "A programming language empowering everyone to build reliable and efficient software.",
+      "entities": {
+        "description": {
+          "urls": []
+        },
+        "url": {
+          "urls": [
+            {
+              "display_url": "rust-lang.org",
+              "expanded_url": "http://www.rust-lang.org",
+              "indices": [
+                0,
+                23
+              ],
+              "url": "https://t.co/REex8dijm6"
+            }
+          ]
+        }
+      },
+      "favourites_count": 29134,
+      "follow_request_sent": false,
+      "followers_count": 56826,
+      "following": true,
+      "friends_count": 0,
+      "geo_enabled": false,
+      "has_extended_profile": false,
+      "id": 165262228,
+      "id_str": "165262228",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": null,
+      "listed_count": 1129,
+      "location": "",
+      "name": "Rust Language",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+      "profile_link_color": "000000",
+      "profile_sidebar_border_color": "000000",
+      "profile_sidebar_fill_color": "000000",
+      "profile_text_color": "000000",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "rustlang",
+      "statuses_count": 18533,
+      "time_zone": null,
+      "translator_type": "none",
+      "url": "https://t.co/REex8dijm6",
+      "utc_offset": null,
+      "verified": false
+    }
+  }
+]

--- a/sample_payloads/user_array.json
+++ b/sample_payloads/user_array.json
@@ -1,0 +1,551 @@
+[
+  {
+    "contributors_enabled": false,
+    "created_at": "Tue Feb 20 14:35:54 +0000 2007",
+    "default_profile": false,
+    "default_profile_image": false,
+    "description": "#BlackTransLivesMatter\n#BlackLivesMatter",
+    "entities": {
+      "description": {
+        "urls": []
+      },
+      "url": {
+        "urls": [
+          {
+            "display_url": "about.twitter.com",
+            "expanded_url": "https://about.twitter.com/",
+            "indices": [
+              0,
+              23
+            ],
+            "url": "https://t.co/TAXQpspyHn"
+          }
+        ]
+      }
+    },
+    "favourites_count": 6392,
+    "follow_request_sent": false,
+    "followers_count": 58075077,
+    "following": false,
+    "friends_count": 1,
+    "geo_enabled": true,
+    "has_extended_profile": true,
+    "id": 783214,
+    "id_str": "783214",
+    "is_translation_enabled": false,
+    "is_translator": false,
+    "lang": null,
+    "listed_count": 87121,
+    "location": "Everywhere",
+    "name": "Twitter",
+    "notifications": false,
+    "profile_background_color": "ACDED6",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme18/bg.gif",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme18/bg.gif",
+    "profile_background_tile": true,
+    "profile_banner_url": "https://pbs.twimg.com/profile_banners/783214/1592864899",
+    "profile_image_url": "http://pbs.twimg.com/profile_images/1270500941498912768/W-80pLvu_normal.jpg",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1270500941498912768/W-80pLvu_normal.jpg",
+    "profile_link_color": "1B95E0",
+    "profile_sidebar_border_color": "FFFFFF",
+    "profile_sidebar_fill_color": "F6F6F6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": true,
+    "protected": false,
+    "screen_name": "Twitter",
+    "status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Fri Jun 19 21:12:32 +0000 2020",
+      "display_text_range": [
+        0,
+        22
+      ],
+      "entities": {
+        "hashtags": [],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/lcGDLzAJIn",
+            "expanded_url": "https://twitter.com/Twitter/status/1274087695145332736/photo/1",
+            "id": 1274087263073255425,
+            "id_str": "1274087263073255425",
+            "indices": [
+              23,
+              46
+            ],
+            "media_url": "http://pbs.twimg.com/media/Ea53nYhUwAEUiEx.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/Ea53nYhUwAEUiEx.jpg",
+            "sizes": {
+              "large": {
+                "h": 1800,
+                "resize": "fit",
+                "w": 1800
+              },
+              "medium": {
+                "h": 1200,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 680,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/lcGDLzAJIn"
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 67472344,
+            "id_str": "67472344",
+            "indices": [
+              13,
+              22
+            ],
+            "name": "Yolanda Sangweni",
+            "screen_name": "YoliZama"
+          }
+        ]
+      },
+      "extended_entities": {
+        "media": [
+          {
+            "display_url": "pic.twitter.com/lcGDLzAJIn",
+            "expanded_url": "https://twitter.com/Twitter/status/1274087695145332736/photo/1",
+            "id": 1274087263073255425,
+            "id_str": "1274087263073255425",
+            "indices": [
+              23,
+              46
+            ],
+            "media_url": "http://pbs.twimg.com/media/Ea53nYhUwAEUiEx.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/Ea53nYhUwAEUiEx.jpg",
+            "sizes": {
+              "large": {
+                "h": 1800,
+                "resize": "fit",
+                "w": 1800
+              },
+              "medium": {
+                "h": 1200,
+                "resize": "fit",
+                "w": 1200
+              },
+              "small": {
+                "h": 680,
+                "resize": "fit",
+                "w": 680
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              }
+            },
+            "type": "photo",
+            "url": "https://t.co/lcGDLzAJIn"
+          }
+        ]
+      },
+      "favorite_count": 4352,
+      "favorited": false,
+      "full_text": "📍 Oakland\n🗣️ @YoliZama https://t.co/lcGDLzAJIn",
+      "geo": null,
+      "id": 1274087695145332736,
+      "id_str": "1274087695145332736",
+      "in_reply_to_screen_name": "Twitter",
+      "in_reply_to_status_id": 1274087694105075714,
+      "in_reply_to_status_id_str": "1274087694105075714",
+      "in_reply_to_user_id": 783214,
+      "in_reply_to_user_id_str": "783214",
+      "is_quote_status": false,
+      "lang": "cy",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 637,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false
+    },
+    "statuses_count": 13676,
+    "time_zone": null,
+    "translator_type": "regular",
+    "url": "https://t.co/TAXQpspyHn",
+    "utc_offset": null,
+    "verified": true
+  },
+  {
+    "contributors_enabled": false,
+    "created_at": "Wed May 23 06:01:13 +0000 2007",
+    "default_profile": false,
+    "default_profile_image": false,
+    "description": "The Real Twitter API. Tweets about API changes, service issues and our Developer Platform. Don't get an answer? It's on my website.",
+    "entities": {
+      "description": {
+        "urls": []
+      },
+      "url": {
+        "urls": [
+          {
+            "display_url": "developer.twitter.com",
+            "expanded_url": "https://developer.twitter.com",
+            "indices": [
+              0,
+              23
+            ],
+            "url": "https://t.co/8IkCzCDr19"
+          }
+        ]
+      }
+    },
+    "favourites_count": 30,
+    "follow_request_sent": false,
+    "followers_count": 6061477,
+    "following": false,
+    "friends_count": 12,
+    "geo_enabled": false,
+    "has_extended_profile": true,
+    "id": 6253282,
+    "id_str": "6253282",
+    "is_translation_enabled": false,
+    "is_translator": false,
+    "lang": null,
+    "listed_count": 12327,
+    "location": "San Francisco, CA",
+    "name": "Twitter API",
+    "notifications": false,
+    "profile_background_color": "C0DEED",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_tile": true,
+    "profile_banner_url": "https://pbs.twimg.com/profile_banners/6253282/1497491515",
+    "profile_image_url": "http://pbs.twimg.com/profile_images/942858479592554497/BbazLO9L_normal.jpg",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/942858479592554497/BbazLO9L_normal.jpg",
+    "profile_link_color": "0084B4",
+    "profile_sidebar_border_color": "C0DEED",
+    "profile_sidebar_fill_color": "DDEEF6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": true,
+    "protected": false,
+    "screen_name": "TwitterAPI",
+    "status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed Apr 29 17:03:24 +0000 2020",
+      "display_text_range": [
+        0,
+        144
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "id": 2244994945,
+            "id_str": "2244994945",
+            "indices": [
+              3,
+              14
+            ],
+            "name": "Twitter Dev",
+            "screen_name": "TwitterDev"
+          }
+        ]
+      },
+      "favorite_count": 0,
+      "favorited": false,
+      "full_text": "RT @TwitterDev: During these unprecedented times, what’s happening on Twitter can help the world better understand &amp; respond to the pandemi…",
+      "geo": null,
+      "id": 1255543219087044608,
+      "id_str": "1255543219087044608",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "retweet_count": 329,
+      "retweeted": false,
+      "retweeted_status": {
+        "contributors": null,
+        "coordinates": null,
+        "created_at": "Wed Apr 29 17:01:38 +0000 2020",
+        "display_text_range": [
+          0,
+          287
+        ],
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "urls": [
+            {
+              "display_url": "blog.twitter.com/developer/en_u…",
+              "expanded_url": "https://blog.twitter.com/developer/en_us/topics/tools/2020/covid19_public_conversation_data.html",
+              "indices": [
+                264,
+                287
+              ],
+              "url": "https://t.co/BPqMcQzhId"
+            }
+          ],
+          "user_mentions": []
+        },
+        "favorite_count": 712,
+        "favorited": false,
+        "full_text": "During these unprecedented times, what’s happening on Twitter can help the world better understand &amp; respond to the pandemic. \n\nWe're launching a free COVID-19 stream endpoint so qualified devs &amp; researchers can study the public conversation in real-time. https://t.co/BPqMcQzhId",
+        "geo": null,
+        "id": 1255542774432063488,
+        "id_str": "1255542774432063488",
+        "in_reply_to_screen_name": null,
+        "in_reply_to_status_id": null,
+        "in_reply_to_status_id_str": null,
+        "in_reply_to_user_id": null,
+        "in_reply_to_user_id_str": null,
+        "is_quote_status": false,
+        "lang": "en",
+        "place": null,
+        "possibly_sensitive": false,
+        "retweet_count": 329,
+        "retweeted": false,
+        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+        "truncated": false
+      },
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false
+    },
+    "statuses_count": 3681,
+    "time_zone": null,
+    "translator_type": "regular",
+    "url": "https://t.co/8IkCzCDr19",
+    "utc_offset": null,
+    "verified": true
+  },
+  {
+    "contributors_enabled": false,
+    "created_at": "Sat Dec 14 04:35:55 +0000 2013",
+    "default_profile": false,
+    "default_profile_image": false,
+    "description": "The voice of Twitter's #DevRel team, and your official source for updates, news, & events about Twitter's API. \n\n#BlackLivesMatter",
+    "entities": {
+      "description": {
+        "urls": []
+      },
+      "url": {
+        "urls": [
+          {
+            "display_url": "developer.twitter.com/en/community",
+            "expanded_url": "https://developer.twitter.com/en/community",
+            "indices": [
+              0,
+              23
+            ],
+            "url": "https://t.co/3ZX3TNiZCY"
+          }
+        ]
+      }
+    },
+    "favourites_count": 2182,
+    "follow_request_sent": false,
+    "followers_count": 507657,
+    "following": false,
+    "friends_count": 1863,
+    "geo_enabled": true,
+    "has_extended_profile": true,
+    "id": 2244994945,
+    "id_str": "2244994945",
+    "is_translation_enabled": false,
+    "is_translator": false,
+    "lang": null,
+    "listed_count": 1552,
+    "location": "127.0.0.1",
+    "name": "Twitter Dev",
+    "notifications": false,
+    "profile_background_color": "FFFFFF",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_tile": false,
+    "profile_banner_url": "https://pbs.twimg.com/profile_banners/2244994945/1590953125",
+    "profile_image_url": "http://pbs.twimg.com/profile_images/1267175364003901441/tBZNFAgA_normal.jpg",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1267175364003901441/tBZNFAgA_normal.jpg",
+    "profile_link_color": "0084B4",
+    "profile_sidebar_border_color": "FFFFFF",
+    "profile_sidebar_fill_color": "DDEEF6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": false,
+    "protected": false,
+    "screen_name": "TwitterDev",
+    "status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Wed Jun 24 16:28:14 +0000 2020",
+      "display_text_range": [
+        0,
+        163
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "blog.twitter.com/developer/en_u…",
+            "expanded_url": "https://blog.twitter.com/developer/en_us/topics/tips/2020/how-to-analyze-the-sentiment-of-your-own-tweets.html",
+            "indices": [
+              140,
+              163
+            ],
+            "url": "https://t.co/IKM3zo6ngu"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 54,
+      "favorited": false,
+      "full_text": "Learn how to create a sentiment score for your Tweets with Microsoft Azure, Python, and Twitter Developer Labs recent search functionality.\nhttps://t.co/IKM3zo6ngu",
+      "geo": null,
+      "id": 1275828087666679809,
+      "id_str": "1275828087666679809",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "retweet_count": 16,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false
+    },
+    "statuses_count": 3563,
+    "time_zone": null,
+    "translator_type": "regular",
+    "url": "https://t.co/3ZX3TNiZCY",
+    "utc_offset": null,
+    "verified": true
+  },
+  {
+    "contributors_enabled": false,
+    "created_at": "Sun Jul 11 02:35:18 +0000 2010",
+    "default_profile": false,
+    "default_profile_image": false,
+    "description": "A programming language empowering everyone to build reliable and efficient software.",
+    "entities": {
+      "description": {
+        "urls": []
+      },
+      "url": {
+        "urls": [
+          {
+            "display_url": "rust-lang.org",
+            "expanded_url": "http://www.rust-lang.org",
+            "indices": [
+              0,
+              23
+            ],
+            "url": "https://t.co/REex8dijm6"
+          }
+        ]
+      }
+    },
+    "favourites_count": 29134,
+    "follow_request_sent": false,
+    "followers_count": 56826,
+    "following": true,
+    "friends_count": 0,
+    "geo_enabled": false,
+    "has_extended_profile": false,
+    "id": 165262228,
+    "id_str": "165262228",
+    "is_translation_enabled": false,
+    "is_translator": false,
+    "lang": null,
+    "listed_count": 1129,
+    "location": "",
+    "name": "Rust Language",
+    "notifications": false,
+    "profile_background_color": "000000",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+    "profile_background_tile": false,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/2392473363/v7txhrjp9pdqrkdtxxp0_normal.png",
+    "profile_link_color": "000000",
+    "profile_sidebar_border_color": "000000",
+    "profile_sidebar_fill_color": "000000",
+    "profile_text_color": "000000",
+    "profile_use_background_image": false,
+    "protected": false,
+    "screen_name": "rustlang",
+    "status": {
+      "contributors": null,
+      "coordinates": null,
+      "created_at": "Mon Jun 01 18:13:12 +0000 2020",
+      "display_text_range": [
+        0,
+        131
+      ],
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "display_url": "twitter.com/bailfundnetwor…",
+            "expanded_url": "https://twitter.com/bailfundnetwork/status/1267324806413729792",
+            "indices": [
+              108,
+              131
+            ],
+            "url": "https://t.co/YtDnBiwEve"
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorite_count": 566,
+      "favorited": false,
+      "full_text": "Rust believes that tech is and always will be political- take some time today to invest in your community.\n\nhttps://t.co/YtDnBiwEve",
+      "geo": null,
+      "id": 1267519582505512960,
+      "id_str": "1267519582505512960",
+      "in_reply_to_screen_name": "rustlang",
+      "in_reply_to_status_id": 1267519580756422659,
+      "in_reply_to_status_id_str": "1267519580756422659",
+      "in_reply_to_user_id": 165262228,
+      "in_reply_to_user_id_str": "165262228",
+      "is_quote_status": true,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "quoted_status_id": 1267324806413729792,
+      "quoted_status_id_str": "1267324806413729792",
+      "quoted_status_permalink": {
+        "display": "twitter.com/bailfundnetwor…",
+        "expanded": "https://twitter.com/bailfundnetwork/status/1267324806413729792",
+        "url": "https://t.co/YtDnBiwEve"
+      },
+      "retweet_count": 163,
+      "retweeted": false,
+      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+      "truncated": false
+    },
+    "statuses_count": 18533,
+    "time_zone": null,
+    "translator_type": "none",
+    "url": "https://t.co/REex8dijm6",
+    "utc_offset": null,
+    "verified": false
+  }
+]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -52,9 +52,10 @@
 //! string. It's also an example of how function parameters are themselves patterns, because i
 //! destructure the pair right in the signature. `>_>`
 //!
-//! `deserialize_datetime` and `deserialize_mime` are glue functions to read these specific items
-//! out in a `Deserialize` implementation. Twitter always gives timestamps in the same format, so
-//! having that function here saves us from having to write the format out everywhere.
+//! `serde_datetime` and `serde_via_string` are helper modules to use with derived
+//! `Serialize`/`Deserialize` implementations. `serde_datetime` loads and saves `DateTime`s with
+//! the format Twitter uses for timestamps, and `serde_via_string` uses `Display` and `FromStr` to
+//! save a string representation of the original type.
 //!
 //! `merge_by` and its companion type `MergeBy` is a copy of the iterator adapter of the same name
 //! from itertools, because i didn't want to add another dependency onto the great towering pile

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -452,13 +452,15 @@ pub mod serde_datetime {
     use serde::de::Error;
     use chrono::TimeZone;
 
+    const DATE_FORMAT: &'static str = "%a %b %d %T %z %Y";
+
     pub fn deserialize<'de, D>(ser: D) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let s = String::deserialize(ser)?;
         let date = (chrono::Utc)
-            .datetime_from_str(&s, "%a %b %d %T %z %Y")
+            .datetime_from_str(&s, DATE_FORMAT)
             .map_err(|e| D::Error::custom(e))?;
         Ok(date)
     }
@@ -467,7 +469,7 @@ pub mod serde_datetime {
     where
         S: Serializer,
     {
-        ser.collect_str(&src.format("%a %b %d %T %z %Y"))
+        ser.collect_str(&src.format(DATE_FORMAT))
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -163,6 +163,30 @@ macro_rules! round_trip {
             $v $f: $t
         ),+ }
 
+        impl $struct_name {
+            /// Returns the string representation of an error from loading JSON from Twitter, if
+            /// applicable.
+            ///
+            /// Use this function if trying to load something from the API gave you a
+            /// deserialization error.
+            pub fn twitter_deser_error(input: serde_json::Value) -> Option<String> {
+                use crate::common::MapString;
+
+                serde_json::from_value::<$raw_name>(input).err().map_string()
+            }
+
+            /// Returns the string representation of an error from loading JSON given by
+            /// serializing this type.
+            ///
+            /// Use this function if trying to load saved JSON from saving previously-loaded data
+            /// gave you a deserialization error.
+            pub fn roundtrip_deser_error(input: serde_json::Value) -> Option<String> {
+                use crate::common::MapString;
+
+                serde_json::from_value::<SerCopy>(input).err().map_string()
+            }
+        }
+
         #[derive(serde::Deserialize)]
         struct SerCopy { $(
             $(#[$attr])*

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -146,10 +146,13 @@ macro_rules! round_trip {
         }
 
         #[allow(unused_qualifications)]
-        impl std::convert::TryFrom<SerEnum> for $struct_name {
-            type Error = crate::error::Error;
+        impl std::convert::TryFrom<SerEnum> for $struct_name
+        where
+            $struct_name: std::convert::TryFrom<$raw_name>,
+        {
+            type Error = <$struct_name as std::convert::TryFrom<$raw_name>>::Error;
 
-            fn try_from(src: SerEnum) -> crate::error::Result<$struct_name> {
+            fn try_from(src: SerEnum) -> std::result::Result<$struct_name, Self::Error> {
                 use std::convert::TryInto;
 
                 match src {

--- a/src/direct/raw.rs
+++ b/src/direct/raw.rs
@@ -200,11 +200,11 @@ impl EventType {
 #[derive(Deserialize)]
 struct DMEvent {
     /// Numeric ID for the direct message.
-    #[serde(deserialize_with = "deser_from_string")]
+    #[serde(with = "serde_via_string")]
     id: u64,
     /// UTC Unix timestamp for when the message was sent, encoded as the number of milliseconds
     /// since the Unix epoch.
-    #[serde(deserialize_with = "deser_from_string")]
+    #[serde(with = "serde_via_string")]
     created_timestamp: i64,
     /// Message data for this event.
     message_create: MessageCreateEvent,
@@ -215,7 +215,7 @@ struct DMEvent {
 struct MessageCreateEvent {
     /// The `message_data` portion of this event.
     message_data: MessageData,
-    #[serde(deserialize_with = "deser_from_string")]
+    #[serde(with = "serde_via_string")]
     /// The numeric User ID of the sender.
     sender_id: u64,
     /// The string ID of the app used to send the message, if it was sent by the authenticated
@@ -272,7 +272,7 @@ struct QuickReplyResponse {
 /// Represents the message target from within a `DMEvent`.
 #[derive(Deserialize)]
 struct MessageTarget {
-    #[serde(deserialize_with = "deser_from_string")]
+    #[serde(with = "serde_via_string")]
     /// The numeric user ID of the recipient of the message.
     recipient_id: u64,
 }

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -43,12 +43,12 @@
 //!   with the parent text. This is useful to show users where the link resolves to, without
 //!   potentially filling up a lot of space with the fullly expanded URL.
 use mime;
-use serde::{Deserialize, Deserializer};
+use serde::{Serialize, Deserialize, Deserializer};
 
-use crate::common::deserialize_mime;
+use crate::common::{deserialize_mime, ser_via_string};
 
 ///Represents a hashtag or symbol extracted from another piece of text.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HashtagEntity {
     ///The byte offsets where the hashtag is located. The first index is the location of the # or $
     ///character; the second is the location of the first character following the hashtag.
@@ -70,7 +70,7 @@ pub struct HashtagEntity {
 ///appending a colon and one of the available sizes in the `MediaSizes` struct. For example, the
 ///cropped thumbnail can be viewed by appending `:thumb` to the end of the URL, and the full-size
 ///image can be viewed by appending `:large`.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MediaEntity {
     ///A shortened URL to display to clients.
     pub display_url: String,
@@ -111,7 +111,7 @@ pub struct MediaEntity {
 }
 
 ///Represents the types of media that can be attached to a tweet.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub enum MediaType {
     ///A static image.
     #[serde(rename = "photo")]
@@ -125,7 +125,7 @@ pub enum MediaType {
 }
 
 ///Represents the available sizes for a media file.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub struct MediaSizes {
     ///Information for a thumbnail-sized version of the media.
     pub thumb: MediaSize,
@@ -138,7 +138,7 @@ pub struct MediaSizes {
 }
 
 ///Represents how an image has been resized for a given size variant.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub enum ResizeMode {
     ///The media was resized to fit one dimension, keeping its aspect ratio.
     #[serde(rename = "fit")]
@@ -149,7 +149,7 @@ pub enum ResizeMode {
 }
 
 ///Represents the dimensions of a media file.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub struct MediaSize {
     ///The size variant's width in pixels.
     pub w: i32,
@@ -160,7 +160,7 @@ pub struct MediaSize {
 }
 
 ///Represents metadata specific to videos.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VideoInfo {
     ///The aspect ratio of the video.
     pub aspect_ratio: (i32, i32),
@@ -173,19 +173,20 @@ pub struct VideoInfo {
 }
 
 ///Represents information about a specific encoding of a video.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VideoVariant {
     ///The bitrate of the video. This value is present for GIFs, but it will be zero.
     pub bitrate: Option<i32>,
     ///The file format of the video variant.
     #[serde(deserialize_with = "deserialize_mime")]
+    #[serde(serialize_with = "ser_via_string")]
     pub content_type: mime::Mime,
     ///The URL for the video variant.
     pub url: String,
 }
 
 ///Represents a link extracted from another piece of text.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UrlEntity {
     ///A truncated URL meant to be displayed inline with the text.
     #[serde(default)]
@@ -203,7 +204,7 @@ pub struct UrlEntity {
 }
 
 ///Represnts a user mention extracted from another piece of text.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MentionEntity {
     ///Numeric ID of the mentioned user.
     #[serde(deserialize_with = "nullable_id")] // Very rarely this field is null

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -45,7 +45,7 @@
 use mime;
 use serde::{Serialize, Deserialize, Deserializer};
 
-use crate::common::{deserialize_mime, ser_via_string};
+use crate::common::serde_via_string;
 
 ///Represents a hashtag or symbol extracted from another piece of text.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -178,8 +178,7 @@ pub struct VideoVariant {
     ///The bitrate of the video. This value is present for GIFs, but it will be zero.
     pub bitrate: Option<i32>,
     ///The file format of the video variant.
-    #[serde(deserialize_with = "deserialize_mime")]
-    #[serde(serialize_with = "ser_via_string")]
+    #[serde(with = "serde_via_string")]
     pub content_type: mime::Mime,
     ///The URL for the video variant.
     pub url: String,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -160,7 +160,7 @@ pub struct List {
     ///to create a link to the list.
     pub uri: String,
     ///UTC timestamp of when the list was created.
-    #[serde(deserialize_with = "deserialize_datetime")]
+    #[serde(with = "serde_datetime")]
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -167,6 +167,8 @@ pub fn response_as_stream(req: Request<Body>) -> TwitterStream {
     TwitterStream::new(req)
 }
 
+pub use crate::common::RoundTrip;
+
 /// Facilities to manually assemble signed requests.
 ///
 /// In case you need to do things that aren't available in the `raw` module, the `RequestBuilder`

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -53,7 +53,7 @@ use futures::Stream;
 use hyper::client::ResponseFuture;
 use hyper::{Body, Request};
 use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{Serialize, Deserialize, Deserializer};
 use serde_json;
 
 use crate::auth::Token;
@@ -298,7 +298,7 @@ impl Stream for TwitterStream {
 /// According to Twitter's documentation, "When displaying a stream of Tweets to end users
 /// (dashboards or live feeds at a presentation or conference, for example) it is suggested that
 /// you set this value to medium."
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub enum FilterLevel {
     /// No filtering.
     #[serde(rename = "none")]

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -220,9 +220,9 @@ round_trip! { raw::RawTweet,
         ///Indicates whether this tweet is a truncated "compatibility" form of an extended tweet whose
         ///full text is longer than 280 characters.
         pub truncated: bool,
-        /////The user who posted this tweet. This field will be absent on tweets included as part of a
-        /////`TwitterUser`.
-        //pub user: Option<Box<user::TwitterUser>>,
+        ///The user who posted this tweet. This field will be absent on tweets included as part of a
+        ///`TwitterUser`.
+        pub user: Option<Box<user::TwitterUser>>,
         ///If present and `true`, indicates that this tweet has been withheld due to a DMCA complaint.
         pub withheld_copyright: bool,
         ///If present, contains two-letter country codes indicating where this tweet is being withheld.
@@ -297,7 +297,7 @@ impl TryFrom<raw::RawTweet> for Tweet {
             retweeted_status: raw.retweeted_status,
             source: raw.source,
             truncated: raw.truncated,
-            // user: raw.user,
+            user: raw.user,
             withheld_copyright: raw.withheld_copyright,
             withheld_in_countries: raw.withheld_in_countries,
             withheld_scope: raw.withheld_scope,

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -996,4 +996,15 @@ mod tests {
             Some("test alt text for the image".to_string())
         );
     }
+
+    #[test]
+    fn roundtrip_deser() {
+        let sample = load_file("sample_payloads/tweet_array.json");
+        let tweets_src: Vec<Tweet> = serde_json::from_str(&sample).unwrap();
+        let json1 = serde_json::to_value(tweets_src).unwrap();
+        let tweets_roundtrip: Vec<Tweet> = serde_json::from_value(json1.clone()).unwrap();
+        let json2 = serde_json::to_value(tweets_roundtrip).unwrap();
+
+        assert_eq!(json1, json2);
+    }
 }

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -153,8 +153,7 @@ round_trip! { raw::RawTweet,
         ///If present, the location coordinate attached to the tweet, as a (latitude, longitude) pair.
         pub coordinates: Option<(f64, f64)>,
         ///UTC timestamp from when the tweet was posted.
-        #[serde(deserialize_with = "deserialize_datetime")]
-        #[serde(serialize_with = "serialize_datetime")]
+        #[serde(with = "serde_datetime")]
         pub created_at: chrono::DateTime<chrono::Utc>,
         ///If the authenticated user has retweeted this tweet, contains the ID of the retweet.
         pub current_user_retweet: Option<u64>,

--- a/src/tweet/mod.rs
+++ b/src/tweet/mod.rs
@@ -188,9 +188,9 @@ round_trip! { raw::RawTweet,
         ///Can contain a language ID indicating the machine-detected language of the text, or "und" if
         ///no language could be detected.
         pub lang: Option<String>,
-        /////When present, the `Place` that this tweet is associated with (but not necessarily where it
-        /////originated from).
-        //pub place: Option<place::Place>,
+        ///When present, the `Place` that this tweet is associated with (but not necessarily where it
+        ///originated from).
+        pub place: Option<place::Place>,
         ///If the tweet has a link, indicates whether the link may contain content that could be
         ///identified as sensitive.
         pub possibly_sensitive: Option<bool>,
@@ -288,7 +288,7 @@ impl TryFrom<raw::RawTweet> for Tweet {
             in_reply_to_screen_name: raw.in_reply_to_screen_name,
             in_reply_to_status_id: raw.in_reply_to_status_id,
             lang: raw.lang,
-            // place: raw.place,
+            place: raw.place,
             possibly_sensitive: raw.possibly_sensitive,
             quoted_status_id: raw.quoted_status_id,
             quoted_status: raw.quoted_status,

--- a/src/tweet/raw.rs
+++ b/src/tweet/raw.rs
@@ -2,15 +2,17 @@ use crate::{place, user};
 use chrono;
 use serde::Deserialize;
 
+use crate::common::{serde_datetime};
+
 use super::{
-    deserialize_datetime, deserialize_tweet_source, ExtendedTweetEntities, FilterLevel, Tweet,
+    deserialize_tweet_source, ExtendedTweetEntities, FilterLevel, Tweet,
     TweetEntities, TweetSource,
 };
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct RawTweet {
     pub coordinates: Option<RawCoordinates>,
-    #[serde(deserialize_with = "deserialize_datetime")]
+    #[serde(with = "serde_datetime")]
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub current_user_retweet: Option<CurrentUserRetweet>,
     pub display_text_range: Option<(usize, usize)>,

--- a/src/tweet/raw.rs
+++ b/src/tweet/raw.rs
@@ -2,7 +2,7 @@ use crate::{place, user};
 use chrono;
 use serde::Deserialize;
 
-use crate::common::{serde_datetime};
+use crate::common::serde_datetime;
 
 use super::{
     deserialize_tweet_source, ExtendedTweetEntities, FilterLevel, Tweet,

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -62,7 +62,7 @@ use std::vec::IntoIter as VecIter;
 
 use chrono;
 use futures::Stream;
-use serde::{Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::common::*;
 use crate::{auth, entities, error, links, tweet};
@@ -109,190 +109,191 @@ impl From<String> for UserID {
     }
 }
 
-/// Represents a Twitter user.
-///
-/// Field-level documentation is mostly ripped wholesale from [Twitter's user
-/// documentation][api-user].
-///
-/// [api-user]: https://dev.twitter.com/overview/api/users
-///
-/// The fields present in this struct can be divided up into a few sections: Profile Information and
-/// Settings.
-///
-/// ## Profile Information
-///
-/// Information here can be considered part of the user's profile. These fields are the "obvious"
-/// visible portion of a profile view.
-///
-/// * `id`
-/// * `screen_name`
-/// * `name`
-/// * `verified`
-/// * `protected`
-/// * `description`
-/// * `location`
-/// * `url`
-/// * `statuses_count`
-/// * `friends_count`
-/// * `followers_count`
-/// * `favourites_count`
-/// * `listed_count`
-/// * `profile_image_url`/`profile_image_url_https`
-/// * `profile_banner_url`
-///
-/// ## Settings Information
-///
-/// Information here can be used to alter the UI around this user, or to provide further metadata
-/// that may not necessarily be user-facing.
-///
-/// * `contributors_enabled`
-/// * `created_at`
-/// * `default_profile_image`
-/// * `follow_request_sent`
-/// * `default_profile`, `profile_background_color`, `profile_background_image_url`,
-///   `profile_background_image_url_https`, `profile_background_tile`, `profile_link_color`,
-///   `profile_sidebar_border_color`, `profile_sidebar_fill_color`, `profile_text_color`,
-///   `profile_use_background_image`: These fields can be used to theme a user's profile page to
-///   look like the settings they've set on the Twitter website.
-/// * `geo_enabled`
-/// * `is_translator`
-/// * `lang`
-/// * `show_all_inline_media`
-/// * `time_zone`/`utc_offset`
-/// * `withheld_in_countries`/`withheld_scope`
-#[derive(Debug, Clone, Deserialize)]
-#[serde(from = "raw::RawTwitterUser")]
-pub struct TwitterUser {
-    /// Indicates this user has an account with "contributor mode" enabled, allowing
-    /// for Tweets issued by the user to be co-authored by another account. Rarely `true`.
-    pub contributors_enabled: bool,
-    /// The UTC timestamp for when this user account was created on Twitter.
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    /// When true, indicates that this user has not altered the theme or background of
-    /// their user profile.
-    pub default_profile: bool,
-    /// When true, indicates that the user has not uploaded their own avatar and a default
-    /// egg avatar is used instead.
-    pub default_profile_image: bool,
-    /// The user-defined string describing their account.
-    pub description: Option<String>,
-    /// Link information that has been parsed out of the `url` or `description` fields given by the
-    /// user.
-    pub entities: UserEntities,
-    /// The number of tweets this user has favorited or liked in the account's lifetime.
-    /// The term "favourites" and its British spelling are used for historical reasons.
-    pub favourites_count: i32,
-    /// When true, indicates that the authenticating user has issued a follow request to
-    /// this protected account.
-    pub follow_request_sent: Option<bool>,
-    /// The number of followers this account has.
+round_trip! { raw::RawTwitterUser,
+    /// Represents a Twitter user.
     ///
-    /// In certain server-stress conditions, this may temporarily mistakenly return 0.
-    pub followers_count: i32,
-    /// The number of users this account follows, aka its "followings".
+    /// Field-level documentation is mostly ripped wholesale from [Twitter's user
+    /// documentation][api-user].
     ///
-    /// In certain server-stress conditions, this may temporarily mistakenly return 0.
-    pub friends_count: i32,
-    /// Indicates whether this user as enabled their tweets to be geotagged.
+    /// [api-user]: https://dev.twitter.com/overview/api/users
     ///
-    /// If this is set for the current user, then they can attach geographic data when
-    /// posting a new Tweet.
-    pub geo_enabled: bool,
-    /// Unique identifier for this user.
-    pub id: u64,
-    /// Indicates whether the user participates in Twitter's translator community.
-    pub is_translator: bool,
-    /// Language code for the user's self-declared interface language.
+    /// The fields present in this struct can be divided up into a few sections: Profile Information and
+    /// Settings.
     ///
-    /// Codes are formatted as a language tag from [BCP 47][]. Only indicates the user's
-    /// interface language, not necessarily the content of their Tweets.
+    /// ## Profile Information
     ///
-    /// [BCP 47]: https://tools.ietf.org/html/bcp47
-    pub lang: Option<String>,
-    /// The number of public lists the user is a member of.
-    pub listed_count: i32,
-    /// The user-entered location field from their profile. Not necessarily parseable
-    /// or even a location.
-    pub location: Option<String>,
-    /// The user-entered display name.
-    pub name: String,
-    /// The hex color chosen by the user for their profile background.
-    pub profile_background_color: String,
-    /// A URL pointing to the background image chosen by the user for their profile. Uses
-    /// HTTP as the protocol.
-    pub profile_background_image_url: Option<String>,
-    /// A URL pointing to the background image chosen by the user for their profile. Uses
-    /// HTTPS as the protocol.
-    pub profile_background_image_url_https: Option<String>,
-    /// Indicates whether the user's `profile_background_image_url` should be tiled when
-    /// displayed.
-    pub profile_background_tile: Option<bool>,
-    /// A URL pointing to the banner image chosen by the user. Uses HTTPS as the protocol.
+    /// Information here can be considered part of the user's profile. These fields are the "obvious"
+    /// visible portion of a profile view.
     ///
-    /// This is a base URL that a size specifier can be appended onto to get variously
-    /// sized images, with size specifiers according to [Profile Images and Banners][profile-img].
+    /// * `id`
+    /// * `screen_name`
+    /// * `name`
+    /// * `verified`
+    /// * `protected`
+    /// * `description`
+    /// * `location`
+    /// * `url`
+    /// * `statuses_count`
+    /// * `friends_count`
+    /// * `followers_count`
+    /// * `favourites_count`
+    /// * `listed_count`
+    /// * `profile_image_url`/`profile_image_url_https`
+    /// * `profile_banner_url`
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
-    pub profile_banner_url: Option<String>,
-    /// A URL pointing to the user's avatar image. Uses HTTP as the protocol. Size
-    /// specifiers can be used according to [Profile Images and Banners][profile-img].
+    /// ## Settings Information
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
-    pub profile_image_url: String,
-    /// A URL pointing to the user's avatar image. Uses HTTPS as the protocol. Size
-    /// specifiers can be used according to [Profile Images and Banners][profile-img].
+    /// Information here can be used to alter the UI around this user, or to provide further metadata
+    /// that may not necessarily be user-facing.
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
-    pub profile_image_url_https: String,
-    /// The hex color chosen by the user to display links in the Twitter UI.
-    pub profile_link_color: String,
-    /// The hex color chosen by the user to display sidebar borders in the Twitter UI.
-    pub profile_sidebar_border_color: String,
-    /// The hex color chosen by the user to display sidebar backgrounds in the Twitter UI.
-    pub profile_sidebar_fill_color: String,
-    /// The hex color chosen by the user to display text in the Twitter UI.
-    pub profile_text_color: String,
-    /// Indicates whether the user wants their uploaded background image to be used.
-    pub profile_use_background_image: bool,
-    /// Indicates whether the user is a [protected][] account.
-    ///
-    /// [protected]: https://support.twitter.com/articles/14016
-    pub protected: bool,
-    /// The screen name or handle identifying this user.
-    ///
-    /// Screen names are unique per-user but can be changed. Use `id` for an immutable identifier
-    /// for an account.
-    ///
-    /// Typically a maximum of 15 characters long, but older accounts may exist with longer screen
-    /// names.
-    pub screen_name: String,
-    /// Indicates that the user would like to see media inline. "Somewhat disused."
-    pub show_all_inline_media: Option<bool>,
-    /// If possible, the most recent tweet or retweet from this user.
-    ///
-    /// "In some circumstances, this data cannot be provided and this field will be omitted, null,
-    /// or empty." Do not depend on this field being filled. Also note that this is actually their
-    /// most-recent tweet, not the status pinned to their profile.
-    ///
-    /// "Perspectival" items within this tweet that depend on the authenticating user
-    /// [may not be completely reliable][stale-embed] in this embed.
-    ///
-    /// [stale-embed]: https://dev.twitter.com/docs/faq/basics/why-are-embedded-objects-stale-or-inaccurate
-    pub status: Option<Box<tweet::Tweet>>,
-    /// The number of tweets (including retweets) posted by this user.
-    pub statuses_count: i32,
-    /// The full name of the time zone the user has set their UI preference to.
-    pub time_zone: Option<String>,
-    /// The website link given by this user in their profile.
-    pub url: Option<String>,
-    /// The UTC offset of `time_zone` in minutes.
-    pub utc_offset: Option<i32>,
-    /// Indicates whether this user is a verified account.
-    pub verified: bool,
-    /// When present, lists the countries this user has been withheld from.
-    pub withheld_in_countries: Option<Vec<String>>,
-    /// When present, indicates whether the content being withheld is a "status" or "user".
-    pub withheld_scope: Option<String>,
+    /// * `contributors_enabled`
+    /// * `created_at`
+    /// * `default_profile_image`
+    /// * `follow_request_sent`
+    /// * `default_profile`, `profile_background_color`, `profile_background_image_url`,
+    ///   `profile_background_image_url_https`, `profile_background_tile`, `profile_link_color`,
+    ///   `profile_sidebar_border_color`, `profile_sidebar_fill_color`, `profile_text_color`,
+    ///   `profile_use_background_image`: These fields can be used to theme a user's profile page to
+    ///   look like the settings they've set on the Twitter website.
+    /// * `geo_enabled`
+    /// * `is_translator`
+    /// * `lang`
+    /// * `show_all_inline_media`
+    /// * `time_zone`/`utc_offset`
+    /// * `withheld_in_countries`/`withheld_scope`
+    #[derive(Debug, Clone)]
+    pub struct TwitterUser {
+        /// Indicates this user has an account with "contributor mode" enabled, allowing
+        /// for Tweets issued by the user to be co-authored by another account. Rarely `true`.
+        pub contributors_enabled: bool,
+        /// The UTC timestamp for when this user account was created on Twitter.
+        pub created_at: chrono::DateTime<chrono::Utc>,
+        /// When true, indicates that this user has not altered the theme or background of
+        /// their user profile.
+        pub default_profile: bool,
+        /// When true, indicates that the user has not uploaded their own avatar and a default
+        /// egg avatar is used instead.
+        pub default_profile_image: bool,
+        /// The user-defined string describing their account.
+        pub description: Option<String>,
+        /// Link information that has been parsed out of the `url` or `description` fields given by the
+        /// user.
+        pub entities: UserEntities,
+        /// The number of tweets this user has favorited or liked in the account's lifetime.
+        /// The term "favourites" and its British spelling are used for historical reasons.
+        pub favourites_count: i32,
+        /// When true, indicates that the authenticating user has issued a follow request to
+        /// this protected account.
+        pub follow_request_sent: Option<bool>,
+        /// The number of followers this account has.
+        ///
+        /// In certain server-stress conditions, this may temporarily mistakenly return 0.
+        pub followers_count: i32,
+        /// The number of users this account follows, aka its "followings".
+        ///
+        /// In certain server-stress conditions, this may temporarily mistakenly return 0.
+        pub friends_count: i32,
+        /// Indicates whether this user as enabled their tweets to be geotagged.
+        ///
+        /// If this is set for the current user, then they can attach geographic data when
+        /// posting a new Tweet.
+        pub geo_enabled: bool,
+        /// Unique identifier for this user.
+        pub id: u64,
+        /// Indicates whether the user participates in Twitter's translator community.
+        pub is_translator: bool,
+        /// Language code for the user's self-declared interface language.
+        ///
+        /// Codes are formatted as a language tag from [BCP 47][]. Only indicates the user's
+        /// interface language, not necessarily the content of their Tweets.
+        ///
+        /// [BCP 47]: https://tools.ietf.org/html/bcp47
+        pub lang: Option<String>,
+        /// The number of public lists the user is a member of.
+        pub listed_count: i32,
+        /// The user-entered location field from their profile. Not necessarily parseable
+        /// or even a location.
+        pub location: Option<String>,
+        /// The user-entered display name.
+        pub name: String,
+        /// The hex color chosen by the user for their profile background.
+        pub profile_background_color: String,
+        /// A URL pointing to the background image chosen by the user for their profile. Uses
+        /// HTTP as the protocol.
+        pub profile_background_image_url: Option<String>,
+        /// A URL pointing to the background image chosen by the user for their profile. Uses
+        /// HTTPS as the protocol.
+        pub profile_background_image_url_https: Option<String>,
+        /// Indicates whether the user's `profile_background_image_url` should be tiled when
+        /// displayed.
+        pub profile_background_tile: Option<bool>,
+        /// A URL pointing to the banner image chosen by the user. Uses HTTPS as the protocol.
+        ///
+        /// This is a base URL that a size specifier can be appended onto to get variously
+        /// sized images, with size specifiers according to [Profile Images and Banners][profile-img].
+        ///
+        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        pub profile_banner_url: Option<String>,
+        /// A URL pointing to the user's avatar image. Uses HTTP as the protocol. Size
+        /// specifiers can be used according to [Profile Images and Banners][profile-img].
+        ///
+        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        pub profile_image_url: String,
+        /// A URL pointing to the user's avatar image. Uses HTTPS as the protocol. Size
+        /// specifiers can be used according to [Profile Images and Banners][profile-img].
+        ///
+        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        pub profile_image_url_https: String,
+        /// The hex color chosen by the user to display links in the Twitter UI.
+        pub profile_link_color: String,
+        /// The hex color chosen by the user to display sidebar borders in the Twitter UI.
+        pub profile_sidebar_border_color: String,
+        /// The hex color chosen by the user to display sidebar backgrounds in the Twitter UI.
+        pub profile_sidebar_fill_color: String,
+        /// The hex color chosen by the user to display text in the Twitter UI.
+        pub profile_text_color: String,
+        /// Indicates whether the user wants their uploaded background image to be used.
+        pub profile_use_background_image: bool,
+        /// Indicates whether the user is a [protected][] account.
+        ///
+        /// [protected]: https://support.twitter.com/articles/14016
+        pub protected: bool,
+        /// The screen name or handle identifying this user.
+        ///
+        /// Screen names are unique per-user but can be changed. Use `id` for an immutable identifier
+        /// for an account.
+        ///
+        /// Typically a maximum of 15 characters long, but older accounts may exist with longer screen
+        /// names.
+        pub screen_name: String,
+        /// Indicates that the user would like to see media inline. "Somewhat disused."
+        pub show_all_inline_media: Option<bool>,
+        /// If possible, the most recent tweet or retweet from this user.
+        ///
+        /// "In some circumstances, this data cannot be provided and this field will be omitted, null,
+        /// or empty." Do not depend on this field being filled. Also note that this is actually their
+        /// most-recent tweet, not the status pinned to their profile.
+        ///
+        /// "Perspectival" items within this tweet that depend on the authenticating user
+        /// [may not be completely reliable][stale-embed] in this embed.
+        ///
+        /// [stale-embed]: https://dev.twitter.com/docs/faq/basics/why-are-embedded-objects-stale-or-inaccurate
+        pub status: Option<Box<tweet::Tweet>>,
+        /// The number of tweets (including retweets) posted by this user.
+        pub statuses_count: i32,
+        /// The full name of the time zone the user has set their UI preference to.
+        pub time_zone: Option<String>,
+        /// The website link given by this user in their profile.
+        pub url: Option<String>,
+        /// The UTC offset of `time_zone` in minutes.
+        pub utc_offset: Option<i32>,
+        /// Indicates whether this user is a verified account.
+        pub verified: bool,
+        /// When present, lists the countries this user has been withheld from.
+        pub withheld_in_countries: Option<Vec<String>>,
+        /// When present, indicates whether the content being withheld is a "status" or "user".
+        pub withheld_scope: Option<String>,
+    }
 }
 
 impl From<raw::RawTwitterUser> for TwitterUser {
@@ -357,7 +358,7 @@ impl From<raw::RawTwitterUser> for TwitterUser {
 }
 
 /// Container for URL entity information that may be paired with a user's profile.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct UserEntities {
     /// URL information that has been parsed out of the user's `description`. If no URLs were
     /// detected, then the contained Vec will be empty.
@@ -371,7 +372,7 @@ pub struct UserEntities {
 }
 
 /// Represents a collection of URL entity information paired with a specific user profile field.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct UserEntityDetail {
     /// Collection of URL entity information.
     ///

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -683,3 +683,20 @@ pub enum Connection {
     #[serde(rename = "muting")]
     Muting,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TwitterUser;
+    use crate::common::tests::load_file;
+
+    #[test]
+    fn roundtrip_deser() {
+        let sample = load_file("sample_payloads/user_array.json");
+        let users_src: Vec<TwitterUser> = serde_json::from_str(&sample).unwrap();
+        let json1 = serde_json::to_value(users_src).unwrap();
+        let users_roundtrip: Vec<TwitterUser> = serde_json::from_value(json1.clone()).unwrap();
+        let json2 = serde_json::to_value(users_roundtrip).unwrap();
+
+        assert_eq!(json1, json2);
+    }
+}

--- a/src/user/raw.rs
+++ b/src/user/raw.rs
@@ -16,7 +16,7 @@ pub struct RawTwitterUser {
     /// for Tweets issued by the user to be co-authored by another account. Rarely `true`.
     pub contributors_enabled: bool,
     /// The UTC timestamp for when this user account was created on Twitter.
-    #[serde(deserialize_with = "deserialize_datetime")]
+    #[serde(with = "serde_datetime")]
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// When true, indicates that this user has not altered the theme or background of
     /// their user profile.


### PR DESCRIPTION
Closes #90 

This PR adds a `Serialize` impl for various types in the library, most notably `Tweet` and `TwitterUser`. Since those types have existing `Deserialize` impls that load via a "raw" type that mirrors Twitter's JSON representation, i needed to introduce a new mechanism to allow loading via *either* Twitter's JSON *or* egg-mode's.

The way i did this for this PR was to introduce a new `round_trip!` macro that wrapped the structs and added some new items used internally by the macro:

* `SerCopy`, a field-for-field copy of the given type,
* `SerEnum`, an enum which can either be the "raw" type or `SerCopy`,
* and a couple derived `Deserialize` implementations that leverage the `#[serde(untagged)]` attribute to drive the deserialization.

One major drawback with this approach is that if the "raw" type gets out-of-sync with Twitter's representation, the only error message you see is `"data did not match any variant of untagged enum SerEnum"`, instead of knowing which field is missing. On the other hand, doing it this way means that there is no overhead of doing the deserialization manually (anyone remember the original `FromJson` impls?) or loading the whole response into a `serde_json::Value` first. I'm posting this provisionally to see if this suits people's purposes, and to ask whether this should wrap other public types in egg-mode.