### PR TITLE
properly deserialize Relationship in user::relation

### DIFF
--- a/src/user/fun.rs
+++ b/src/user/fun.rs
@@ -127,7 +127,14 @@ where
 
     let req = get(links::users::FRIENDSHIP_SHOW, token, Some(&params));
 
-    request_with_json_response(req).await
+    // the relationship returned by Twitter is actually contained within a `"relationship"` field,
+    // so this wrapper struct makes sure the data is loaded correctly
+    #[derive(Deserialize)]
+    struct RelationWrapper { relationship: Relationship }
+
+    let resp: Response<RelationWrapper> = request_with_json_response(req).await?;
+
+    Ok(Response::map(resp, |r| r.relationship))
 }
 
 /// Lookup the relations between the authenticated user and the given accounts.


### PR DESCRIPTION
Closes https://github.com/egg-mode-rs/egg-mode/issues/96

Looks like this was missed in the initial Serde conversion. The relationship info returned by Twitter is wrapped in an object that has a single `"relationship"` field with the data we actually return. The original `FromJson` impl accounted for this, but when it was replaced with a straight `#[derive(Deserialize)]`, it broke that endpoint. This PR creates the proper wrapper struct when loading the relationship data.