### PR TITLE
Update links to API docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ mention the API effect of trying to follow a protected user. When documenting [`
 tried just that, to see what would happen, and I included that note in the documentation. If you
 notice such holes in egg-mode documentation, please post an issue or create a pull request!
 
-[`friendships/create`]: https://dev.twitter.com/rest/reference/post/friendships/create
+[`friendships/create`]: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create
 [`user::follow`]: https://docs.rs/egg-mode/0.14.0/egg_mode/user/fn.follow.html
 
 ## Code Contributions
@@ -79,9 +79,9 @@ return a list of items, and have `since_id`/`max_id` parameters to load various 
 This interaction was wrapped into the respective `Timeline` structs, which handle this pagination
 without the user having to juggle these tweet IDs for basic scenarios.
 
-[retweeters-of]: https://dev.twitter.com/rest/reference/get/statuses/retweeters/ids
-[followers-of]: https://dev.twitter.com/rest/reference/get/followers/list
-[list-ownerships]: https://dev.twitter.com/rest/reference/get/lists/ownerships
+[retweeters-of]: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
+[followers-of]: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list
+[list-ownerships]: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships
 [CursorIter]: https://docs.rs/egg-mode/0.14.0/egg_mode/cursor/struct.CursorIter.html
 
 If you're adding new endpoints, check to make sure whether they follow one of these patterns. That

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ alongside them.
 I've grouped them by API heading, then by a rough category and data structure. Endpoints that just
 return a list of IDs of something are grouped in with the rest of the main structure's list.
 
-## [OAuth](https://dev.twitter.com/oauth/overview)
+## [OAuth](https://developer.twitter.com/en/docs/basics/authentication/oauth-1-0a)
 
 - [x] oauth/request\_token (`request_token`)
 - [x] oauth/authenticate (`authenticate_url`)
@@ -16,7 +16,7 @@ return a list of IDs of something are grouped in with the rest of the main struc
 - [x] oauth2/token (`bearer_token`)
 - [x] oauth2/invalidate\_token (`invalidate_bearer`)
 
-## [Public API](https://dev.twitter.com/rest/public)
+## [Public API](https://developer.twitter.com/en/docs/api-reference-index)
 
 ### Statuses
 
@@ -161,7 +161,7 @@ return a list of IDs of something are grouped in with the rest of the main struc
 
 - [x] account/verify\_credentials (`verify_tokens`)
 
-## [Media API](https://dev.twitter.com/rest/media)
+## [Media API](https://developer.twitter.com/en/docs/media/upload-media/api-reference)
 
 - [x] media/upload (INIT) (`media::UploadFuture`)
 - [x] media/upload (APPEND) (`media::UploadFuture`)
@@ -169,7 +169,7 @@ return a list of IDs of something are grouped in with the rest of the main struc
 - [x] media/upload (STATUS) (`media::UploadFuture`)
 - [x] media/metadata/create (`media::UploadBuilder::alt_text`)
 
-## [Collections API](https://dev.twitter.com/rest/collections)
+## [Collections API](https://developer.twitter.com/en/docs/tweets/curate-a-collection/api-reference)
 
 - [ ] collections/list
 - [ ] collections/show
@@ -182,7 +182,7 @@ return a list of IDs of something are grouped in with the rest of the main struc
 - [ ] collections/entries/curate
 - [ ] collections/entries/move
 
-## [Streaming API](https://dev.twitter.com/streaming/overview)
+## [Streaming API](https://developer.twitter.com/en/docs/tweets/sample-realtime/api-reference)
 
 The firehose is unavailable to the general public, so I don't plan to implement it unless asked.
 (It shouldn't be much different from the other streams, though.)

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -9,10 +9,10 @@
 //! `HashtagEntity` describes a hashtag or stock symbol extracted from a tweet.
 //!
 //! For more information on the data in these structures, see Twitter's documentation for
-//! [Entities][] and [Entities in Objects][obj].
+//! [Entities Object][ent] and [Extended Entities Object][ext-ent].
 //!
-//! [Entities]: https://dev.twitter.com/overview/api/entities
-//! [obj]: https://dev.twitter.com/overview/api/entities-in-twitter-objects
+//! [ent]: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object
+//! [ext-ent]: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/extended-entities-object
 //!
 //! ## Entity Ranges
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ pub struct TwitterErrorCode {
     ///The numeric error code returned by Twitter. A list of possible error codes can be found in
     ///the [API documentation][error-codes].
     ///
-    ///[error-codes]: https://dev.twitter.com/overview/api/response-codes
+    ///[error-codes]: https://developer.twitter.com/en/docs/basics/response-codes
     pub code: i32,
 }
 

--- a/src/place/mod.rs
+++ b/src/place/mod.rs
@@ -49,7 +49,7 @@ pub struct Place {
     ///Map of miscellaneous information about this place. See [Twitter's documentation][attrib] for
     ///details and common attribute keys.
     ///
-    ///[attrib]: https://dev.twitter.com/overview/api/places#attributes
+    ///[attrib]: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/geo-objects#place
     pub attributes: HashMap<String, String>,
     ///A bounding box of latitude/longitude coordinates that encloses this place.
     #[serde(with = "serde_bounding_box")]
@@ -295,7 +295,7 @@ impl SearchBuilder {
     ///this search, if you know them. This function may be called multiple times with different
     ///`attribute_key` values to combine attribute search parameters.
     ///
-    ///[attrs]: https://dev.twitter.com/overview/api/places#attributes
+    ///[attrs]: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/geo-objects#place
     ///
     ///For example, `.attribute("street_address", "123 Main St")` searches for places with the
     ///given street address.

--- a/src/search.rs
+++ b/src/search.rs
@@ -41,8 +41,8 @@
 //! page][search-place]. A future version of egg-mode might break these options into further
 //! methods on `SearchBuilder`.
 //!
-//! [search-doc]: https://dev.twitter.com/rest/public/search
-//! [search-place]: https://dev.twitter.com/rest/public/search-by-place
+//! [search-doc]: https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
+//! [search-place]: https://developer.twitter.com/en/docs/tweets/search/guides/tweets-by-place
 
 use std::fmt;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -126,7 +126,7 @@ pub async fn rate_limit_status_raw(token: &auth::Token) -> Result<Response<serde
 ///fields, treat the whole URL as if it were as long as the number of characters given in this
 ///struct.
 ///
-///[t.co URLs]: https://dev.twitter.com/overview/t.co
+///[t.co URLs]: https://developer.twitter.com/en/docs/basics/tco
 ///
 ///Finally, loading `non_username_paths` allows you to handle `twitter.com/[name]` links as if they
 ///were a user mention, while still keeping site-level links working properly.

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -112,10 +112,10 @@ impl From<String> for UserID {
 round_trip! { raw::RawTwitterUser,
     /// Represents a Twitter user.
     ///
-    /// Field-level documentation is mostly ripped wholesale from [Twitter's user
-    /// documentation][api-user].
+    /// Field-level documentation is mostly ripped wholesale from the previous
+    /// edition of [Twitter's user documentation][api-user].
     ///
-    /// [api-user]: https://dev.twitter.com/overview/api/users
+    /// [api-user]: https://web.archive.org/web/20161114173522/https://dev.twitter.com/overview/api/users
     ///
     /// The fields present in this struct can be divided up into a few sections: Profile Information and
     /// Settings.
@@ -232,17 +232,17 @@ round_trip! { raw::RawTwitterUser,
         /// This is a base URL that a size specifier can be appended onto to get variously
         /// sized images, with size specifiers according to [Profile Images and Banners][profile-img].
         ///
-        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
         pub profile_banner_url: Option<String>,
         /// A URL pointing to the user's avatar image. Uses HTTP as the protocol. Size
         /// specifiers can be used according to [Profile Images and Banners][profile-img].
         ///
-        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
         pub profile_image_url: String,
         /// A URL pointing to the user's avatar image. Uses HTTPS as the protocol. Size
         /// specifiers can be used according to [Profile Images and Banners][profile-img].
         ///
-        /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+        /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
         pub profile_image_url_https: String,
         /// The hex color chosen by the user to display links in the Twitter UI.
         pub profile_link_color: String,
@@ -277,7 +277,7 @@ round_trip! { raw::RawTwitterUser,
         /// "Perspectival" items within this tweet that depend on the authenticating user
         /// [may not be completely reliable][stale-embed] in this embed.
         ///
-        /// [stale-embed]: https://dev.twitter.com/docs/faq/basics/why-are-embedded-objects-stale-or-inaccurate
+        /// [stale-embed]: https://web.archive.org/web/20160617182407/https://dev.twitter.com/faq#41
         pub status: Option<Box<tweet::Tweet>>,
         /// The number of tweets (including retweets) posted by this user.
         pub statuses_count: i32,

--- a/src/user/raw.rs
+++ b/src/user/raw.rs
@@ -83,17 +83,17 @@ pub struct RawTwitterUser {
     /// This is a base URL that a size specifier can be appended onto to get variously
     /// sized images, with size specifiers according to [Profile Images and Banners][profile-img].
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+    /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
     pub profile_banner_url: Option<String>,
     /// A URL pointing to the user's avatar image. Uses HTTP as the protocol. Size
     /// specifiers can be used according to [Profile Images and Banners][profile-img].
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+    /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
     pub profile_image_url: String,
     /// A URL pointing to the user's avatar image. Uses HTTPS as the protocol. Size
     /// specifiers can be used according to [Profile Images and Banners][profile-img].
     ///
-    /// [profile-img]: https://dev.twitter.com/overview/general/user-profile-images-and-banners
+    /// [profile-img]: https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
     pub profile_image_url_https: String,
     /// The hex color chosen by the user to display links in the Twitter UI.
     pub profile_link_color: String,
@@ -128,7 +128,7 @@ pub struct RawTwitterUser {
     /// "Perspectival" items within this tweet that depend on the authenticating user
     /// [may not be completely reliable][stale-embed] in this embed.
     ///
-    /// [stale-embed]: https://dev.twitter.com/docs/faq/basics/why-are-embedded-objects-stale-or-inaccurate
+    /// [stale-embed]: https://web.archive.org/web/20160617182407/https://dev.twitter.com/faq#41
     pub status: Option<Box<tweet::Tweet>>,
     /// The number of tweets (including retweets) posted by this user.
     pub statuses_count: i32,


### PR DESCRIPTION
Update links to the old API documentation to point to the correct page.

Closes https://github.com/egg-mode-rs/egg-mode/issues/37