### PR TITLE
Implement API for getting locations with trending topics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ pub mod service;
 pub mod stream;
 pub mod tweet;
 pub mod user;
+pub mod trend;
 
 pub use crate::auth::{Token, KeyPair};
 pub use crate::common::{Response, ResponseIter, RateLimit};

--- a/src/links.rs
+++ b/src/links.rs
@@ -128,3 +128,7 @@ pub mod stream {
     pub const SAMPLE: &'static str = "https://stream.twitter.com/1.1/statuses/sample.json";
     pub const FILTER: &'static str = "https://stream.twitter.com/1.1/statuses/filter.json";
 }
+
+pub mod trend {
+    pub const CLOSEST: &'static str = "https://api.twitter.com/1.1/trends/closest.json";
+}

--- a/src/links.rs
+++ b/src/links.rs
@@ -131,4 +131,5 @@ pub mod stream {
 
 pub mod trend {
     pub const CLOSEST: &'static str = "https://api.twitter.com/1.1/trends/closest.json";
+    pub const AVAILABLE: &'static str = "https://api.twitter.com/1.1/trends/available.json";
 }

--- a/src/trend/fun.rs
+++ b/src/trend/fun.rs
@@ -18,3 +18,9 @@ pub async fn closest(
 
     request_with_json_response(req).await
 }
+
+///Returns the locations that Twitter has trending topic information for.
+pub async fn available(token: &auth::Token) -> Result<Response<Vec<TrendLocation>>> {
+    let req = get(links::trend::AVAILABLE, token, None);
+    request_with_json_response(req).await
+}

--- a/src/trend/fun.rs
+++ b/src/trend/fun.rs
@@ -1,0 +1,20 @@
+use crate::common::*;
+use crate::error::Result;
+use crate::trend::TrendLocation;
+use crate::{auth, links};
+
+///Returns the locations that Twitter has trending topic information for, closest to a
+///specified location.
+pub async fn closest(
+    lat: f32,
+    long: f32,
+    token: &auth::Token,
+) -> Result<Response<Vec<TrendLocation>>> {
+    let params = ParamList::new()
+        .add_param("lat", lat.to_string())
+        .add_param("long", long.to_string());
+
+    let req = get(links::trend::CLOSEST, token, Some(&params));
+
+    request_with_json_response(req).await
+}

--- a/src/trend/mod.rs
+++ b/src/trend/mod.rs
@@ -1,0 +1,60 @@
+//! Sturcts and functions for working with trending topic in Twitter.
+//!
+//! In this module, you are able to get locations with trending topics.
+//!
+//! ## Types
+//! - `TrendLocation`: the element of trending information returned by trend API
+//! - `PlaceType`: a member in `TrendLocation`, which includes the code and related name
+//!   to specify the kind of place
+use serde::{Deserialize, Serialize};
+
+mod fun;
+mod raw;
+
+pub use self::fun::*;
+
+round_trip! { raw::RawTrendLocation,
+    ///Reprsent the locations that Twitter has trending topic information
+    #[derive(Debug, Clone)]
+    pub struct TrendLocation {
+        ///The country of the location that Twitter has trending topic information for.
+        pub country: String,
+        ///short alphabetic or numeric geographical codes developed to represent countries
+        ///and dependent areas.
+        pub country_code: String,
+        ///The location with trending topic information.
+        pub name: String,
+        ///The woeid of the parent place.
+        pub parentid: u32,
+        ///The code and related name to specify the kind of location.
+        pub place_type: PlaceType,
+        ///The related url of woeid of the location. Note that the url returned in the response,
+        ///is no longer valid.
+        pub url: String,
+        ///The "where on earth identifier"
+        pub woeid: u32
+    }
+}
+
+impl From<raw::RawTrendLocation> for TrendLocation {
+    fn from(raw: raw::RawTrendLocation) -> TrendLocation {
+        TrendLocation {
+            country: raw.country,
+            country_code: raw.country_code,
+            name: raw.name,
+            parentid: raw.parentid,
+            place_type: raw.place_type,
+            url: raw.url,
+            woeid: raw.woeid,
+        }
+    }
+}
+
+///The code and related name to specify the kind of location.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlaceType {
+    ///The code of the location type
+    pub code: u32,
+    ///The name of the location type
+    pub name: String,
+}

--- a/src/trend/mod.rs
+++ b/src/trend/mod.rs
@@ -21,7 +21,7 @@ round_trip! { raw::RawTrendLocation,
         pub country: String,
         ///short alphabetic or numeric geographical codes developed to represent countries
         ///and dependent areas.
-        pub country_code: String,
+        pub country_code: Option<String>,
         ///The location with trending topic information.
         pub name: String,
         ///The woeid of the parent place.

--- a/src/trend/raw.rs
+++ b/src/trend/raw.rs
@@ -1,0 +1,15 @@
+use serde::Deserialize;
+
+use super::PlaceType;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawTrendLocation {
+    pub country: String,
+    pub country_code: String,
+    pub name: String,
+    pub parentid: u32,
+    pub place_type: PlaceType,
+    pub url: String,
+    pub woeid: u32,
+}

--- a/src/trend/raw.rs
+++ b/src/trend/raw.rs
@@ -6,7 +6,7 @@ use super::PlaceType;
 #[serde(rename_all = "camelCase")]
 pub struct RawTrendLocation {
     pub country: String,
-    pub country_code: String,
+    pub country_code: Option<String>,
     pub name: String,
     pub parentid: u32,
     pub place_type: PlaceType,


### PR DESCRIPTION
Since the API is needed by myself, I try to add [`trend/closest`](https://developer.twitter.com/en/docs/twitter-api/v1/trends/locations-with-trending-topics/api-reference/get-trends-closest) and [`trend/available`](https://developer.twitter.com/en/docs/twitter-api/v1/trends/locations-with-trending-topics/api-reference/get-trends-available) in the new patch.

I may make some errors since I am not so familiar with the API and only implement it to meet my requirement. So I sincerely appreciate your review, and it's fine to point out if there are any bad or improvable codes/documents. I'll try to figure it out and fix them!