### PR TITLE
Add `Accept-Encoding` when making API requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0"
 sha-1 = "0.9"
 thiserror = "1.0.11"
 tokio = { version = "1.0", features = ["time"] }
+tower-http = { version = "0.1", features = ["decompression-br", "decompression-gzip"] }
 url = "2.1.1"
 
 [features]

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -5,8 +5,10 @@ use crate::error::Error::{self, *};
 use crate::error::{Result, TwitterErrors};
 
 use hyper::client::{HttpConnector, ResponseFuture};
+use hyper::service::Service;
 use hyper::{self, Body, Request};
 use serde::{de::DeserializeOwned, Deserialize};
+use tower_http::decompression::{self, Decompression};
 
 use std::convert::TryFrom;
 
@@ -193,15 +195,27 @@ pub fn get_response(request: Request<Body>) -> ResponseFuture {
     client.request(request)
 }
 
+/// Similar to `get_response`, but makes the request with some `Accept-Encoding`s.
+///
+/// Codes inside `egg-mode` crate should prefer this function to `get_response`.
+pub fn get_response2(request: Request<Body>) -> decompression::ResponseFuture<ResponseFuture> {
+    let connector = new_https_connector();
+    let mut client = Decompression::new(hyper::Client::builder().build(connector));
+    client.call(request)
+}
+
 // n.b. this function is re-exported in the `raw` module - these docs are public!
 /// Loads the given request, parses the headers and response for potential errors given by Twitter,
 /// and returns the headers and raw bytes returned from the response.
 pub async fn raw_request(request: Request<Body>) -> Result<(Headers, Vec<u8>)> {
     let connector = new_https_connector();
-    let client = hyper::Client::builder().build(connector);
-    let resp = client.request(request).await?;
+    let mut client = Decompression::new(hyper::Client::builder().build(connector));
+    let resp = client.call(request).await?;
     let (parts, body) = resp.into_parts();
-    let body: Vec<_> = hyper::body::to_bytes(body).await?.to_vec();
+    let body: Vec<_> = hyper::body::to_bytes(body)
+        .await
+        .map_err(Error::from_decompression_error)?
+        .to_vec();
     if let Ok(errors) = serde_json::from_slice::<TwitterErrors>(&body) {
         if errors.errors.iter().any(|e| e.code == 88)
             && parts.headers.contains_key(X_RATE_LIMIT_RESET)

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{self, fmt};
 use tokio;
+use tower_http::BodyOrIoError;
 
 use crate::common::Headers;
 
@@ -170,4 +171,13 @@ pub enum Error {
     ///panic if it receives malformed headers or the like.
     #[error("Error converting headers: {}", _0)]
     HeaderConvertError(#[from] std::num::ParseIntError),
+}
+
+impl Error {
+    pub(crate) fn from_decompression_error(e: BodyOrIoError<hyper::Error>) -> Self {
+        match e {
+            BodyOrIoError::Body(e) => e.into(),
+            BodyOrIoError::Io(e) => e.into(),
+        }
+    }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -50,11 +50,13 @@ use std::task::{Context, Poll};
 use std::{self, io};
 
 use futures::Stream;
+use hyper::body::HttpBody;
 use hyper::client::ResponseFuture;
 use hyper::{Body, Request};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
+use tower_http::decompression::{self, DecompressionBody};
 
 use crate::auth::Token;
 use crate::common::*;
@@ -209,8 +211,8 @@ impl FromStr for StreamMessage {
 pub struct TwitterStream {
     buf: Vec<u8>,
     request: Option<Request<Body>>,
-    response: Option<ResponseFuture>,
-    body: Option<Body>,
+    response: Option<decompression::ResponseFuture<ResponseFuture>>,
+    body: Option<DecompressionBody<Body>>,
 }
 
 impl TwitterStream {
@@ -229,7 +231,7 @@ impl Stream for TwitterStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         if let Some(req) = self.request.take() {
-            self.response = Some(get_response(req));
+            self.response = Some(get_response2(req));
         }
 
         if let Some(mut resp) = self.response.take() {
@@ -253,7 +255,7 @@ impl Stream for TwitterStream {
 
         if let Some(mut body) = self.body.take() {
             loop {
-                match Pin::new(&mut body).poll_next(cx) {
+                match Pin::new(&mut body).poll_data(cx) {
                     Poll::Pending => {
                         self.body = Some(body);
                         return Poll::Pending;
@@ -263,7 +265,7 @@ impl Stream for TwitterStream {
                     }
                     Poll::Ready(Some(Err(e))) => {
                         self.body = Some(body);
-                        return Poll::Ready(Some(Err(e.into())));
+                        return Poll::Ready(Some(Err(error::Error::from_decompression_error(e))));
                     }
                     Poll::Ready(Some(Ok(chunk))) => {
                         self.buf.extend(&*chunk);


### PR DESCRIPTION
This uses `tower-http` crate's [`Decompression`] middleware, which adds `Accept-Encoding`s to the requests and transparently decodes the response bodies. It should significantly reduce network traffic.

The REST API supports the efficient `br` encoding but the Streaming API v1 supports the `gzip` encoding only, so I enabled both the encodings.

[`Decompression`]: https://docs.rs/tower-http/0.1.1/tower_http/decompression/struct.Decompression.html